### PR TITLE
Fix #25: use clap argument for the site's name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,6 @@ use frontmatter::extract;
 use html::generate_html;
 use json::manifest;
 use metatags::generate_metatags;
-use std::env;
 use std::{error::Error, fs, path::Path};
 use template::render_page;
 
@@ -219,28 +218,18 @@ pub fn generate_navigation(files: &[File]) -> String {
 pub fn compile(
     src_dir: &Path,
     out_dir: &Path,
+    site_name: String,
 ) -> Result<(), Box<dyn Error>> {
     // Constants
     let src_dir = Path::new(src_dir);
     let out_dir = Path::new(out_dir);
 
-    // Get the value of the "new" argument
-    let mut site_name = match env::args().nth(1) {
-        Some(value) => value,
-        None => "Shokunin".to_owned(),
-    };
-    if site_name.starts_with("--new=") {
-        site_name = site_name[6..].to_owned();
-        site_name = site_name.replace(' ', "_");
-    } else {
-        site_name = "Shokunin".to_owned();
-    }
     println!("❯ Generating a new site: \"{}\"", site_name);
 
     // Delete the output directory
     println!("\n❯ Deleting any previous directory...");
     fs::remove_dir_all(out_dir)?;
-    fs::remove_dir(site_name.clone())?;
+    fs::remove_dir(Path::new(&site_name))?;
     println!("  Done.\n");
 
     // Creating the template directory

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -79,7 +79,7 @@ pub fn args(matches: &ArgMatches) -> Result<(), String> {
     }
 
     // Create the new project
-    let new_project = compile(src_dir, out_dir);
+    let new_project = compile(src_dir, out_dir, project_src);
     match new_project {
         Ok(_) => Ok(()),
         Err(e) => Err(format!("❌ Error: {}", e)),


### PR DESCRIPTION
This fixes #25. It passes the clap's output for the `new`-argument to the compile function instead of manually reading it inside the function with `match env::args().nth(1)`.

This also doesn't break if the user tries to pass an empty string to the new argument because clap throws an error beforehand. 