### PR TITLE
Argument to provide a template folder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ clap = "4.1.11"
 comrak = "0.16.0"
 reqwest = { version = "0.11.15", features = ["blocking", "json"] }
 serde_json = "1.0.94"
+tempfile = "3.4.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.10"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,6 +60,14 @@ pub fn build() -> Result<ArgMatches, Error> {
                 .short('o')
                 .value_name("OUTPUT"),
         )
+        .arg(
+            Arg::new("template")
+                .help("Location of the template directory.")
+                .long("template")
+                .short('t')
+                .value_name("TEMPLATE"),
+        )
+ 
         .after_help(
             "\x1b[1;4mDocumentation:\x1b[0m\n\n  https://shokunin.one\n\n\x1b[1;4mLicense:\x1b[0m\n  The project is licensed under the terms of both the MIT license and the Apache License (Version 2.0).",
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,9 +349,9 @@ pub fn compile(
     // Move the output directory to the public directory
     println!("❯ Moving output directory...");
     let public_dir = Path::new("public");
+    fs::remove_dir_all(public_dir)?;
     let site_name = site_name.replace(' ', "_");
     let new_project_dir = public_dir.join(site_name);
-    fs::remove_dir_all(&new_project_dir)?;
     fs::create_dir_all(&new_project_dir)?;
     fs::rename(out_dir, &new_project_dir)?;
     println!("  Done.\n");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ pub fn generate_navigation(files: &[File]) -> String {
 pub fn compile(
     src_dir: &Path,
     out_dir: &Path,
-    template_dir: &Path,
+    template_path: Option<&String>,
     site_name: String,
 ) -> Result<(), Box<dyn Error>> {
     // Constants
@@ -233,11 +233,11 @@ pub fn compile(
     fs::remove_dir(Path::new(&site_name))?;
     println!("  Done.\n");
 
-    // // Creating the template directory
-    // println!("\n❯ Creating template directory...");
-    // create_template_folder()
-    //     .expect("❌ Error: Could not create template directory");
-    // println!("  Done.\n");
+    // Creating the template directory
+    println!("\n❯ Creating template directory...");
+    let template_path = create_template_folder(template_path)
+        .expect("❌ Error: Could not create template directory");
+    println!("  Done.\n");
 
     // Create the output directory
     println!("❯ Creating output directory...");
@@ -279,7 +279,7 @@ pub fn compile(
                 .as_str(),
                 css: "style.css",
                 navigation: &navigation,
-            }, &template_dir)
+            }, &template_path)
             .unwrap();
 
             // Generate JSON

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,7 @@ pub fn generate_navigation(files: &[File]) -> String {
 pub fn compile(
     src_dir: &Path,
     out_dir: &Path,
+    template_dir: &Path,
     site_name: String,
 ) -> Result<(), Box<dyn Error>> {
     // Constants
@@ -232,11 +233,11 @@ pub fn compile(
     fs::remove_dir(Path::new(&site_name))?;
     println!("  Done.\n");
 
-    // Creating the template directory
-    println!("\n❯ Creating template directory...");
-    create_template_folder()
-        .expect("❌ Error: Could not create template directory");
-    println!("  Done.\n");
+    // // Creating the template directory
+    // println!("\n❯ Creating template directory...");
+    // create_template_folder()
+    //     .expect("❌ Error: Could not create template directory");
+    // println!("  Done.\n");
 
     // Create the output directory
     println!("❯ Creating output directory...");
@@ -278,7 +279,7 @@ pub fn compile(
                 .as_str(),
                 css: "style.css",
                 navigation: &navigation,
-            })
+            }, &template_dir)
             .unwrap();
 
             // Generate JSON
@@ -348,9 +349,9 @@ pub fn compile(
     // Move the output directory to the public directory
     println!("❯ Moving output directory...");
     let public_dir = Path::new("public");
-    fs::remove_dir_all(public_dir)?;
     let site_name = site_name.replace(' ', "_");
     let new_project_dir = public_dir.join(site_name);
+    fs::remove_dir_all(&new_project_dir)?;
     fs::create_dir_all(&new_project_dir)?;
     fs::rename(out_dir, &new_project_dir)?;
     println!("  Done.\n");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -62,18 +62,12 @@ pub fn args(matches: &ArgMatches) -> Result<(), String> {
         }
     };
 
-    let arg_template = match matches.get_one::<String>("template") {
-        Some(out) => out.to_owned(),
-        None => {
-            return Err("❌ Error: Argument \"template\" is required but missing.".to_owned());
-        }
-    };
+    let arg_template = matches.get_one::<String>("template");
 
     // Create Path objects for the content and output directories
     let project_dir = Path::new(&project_src);
     let src_dir = Path::new(&arg_src);
     let out_dir = Path::new(&arg_out);
-    let template_dir = Path::new(&arg_template);
 
     // Ensure source and output directories exist or create them
     if let Err(e) = directory(project_dir, "new") {
@@ -85,13 +79,10 @@ pub fn args(matches: &ArgMatches) -> Result<(), String> {
     if let Err(e) = directory(out_dir, "output") {
         return Err(format!("❌ Error: {}", e));
     }
-    if let Err(e) = directory(template_dir, "template") {
-        return Err(format!("❌ Error: {}", e));
-    }
 
     // Create the new project
     let new_project =
-        compile(src_dir, out_dir, template_dir, project_src);
+        compile(src_dir, out_dir, arg_template, project_src);
     match new_project {
         Ok(_) => Ok(()),
         Err(e) => Err(format!("❌ Error: {}", e)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -62,10 +62,18 @@ pub fn args(matches: &ArgMatches) -> Result<(), String> {
         }
     };
 
+    let arg_template = match matches.get_one::<String>("template") {
+        Some(out) => out.to_owned(),
+        None => {
+            return Err("❌ Error: Argument \"template\" is required but missing.".to_owned());
+        }
+    };
+
     // Create Path objects for the content and output directories
     let project_dir = Path::new(&project_src);
     let src_dir = Path::new(&arg_src);
     let out_dir = Path::new(&arg_out);
+    let template_dir = Path::new(&arg_template);
 
     // Ensure source and output directories exist or create them
     if let Err(e) = directory(project_dir, "new") {
@@ -77,9 +85,13 @@ pub fn args(matches: &ArgMatches) -> Result<(), String> {
     if let Err(e) = directory(out_dir, "output") {
         return Err(format!("❌ Error: {}", e));
     }
+    if let Err(e) = directory(template_dir, "template") {
+        return Err(format!("❌ Error: {}", e));
+    }
 
     // Create the new project
-    let new_project = compile(src_dir, out_dir, project_src);
+    let new_project =
+        compile(src_dir, out_dir, template_dir, project_src);
     match new_project {
         Ok(_) => Ok(()),
         Err(e) => Err(format!("❌ Error: {}", e)),

--- a/src/template.rs
+++ b/src/template.rs
@@ -109,7 +109,10 @@ pub fn render_template(
 /// error, it returns `Err(error)`, where `error` is a string describing
 /// the error that occurred.
 ///
-pub fn render_page(options: &PageOptions) -> Result<String, String> {
+pub fn render_page(
+    options: &PageOptions,
+    template_dir: &Path,
+) -> Result<String, String> {
     let mut context = HashMap::new();
     context.insert("content", options.content);
     context.insert("copyright", options.copyright);
@@ -122,7 +125,8 @@ pub fn render_page(options: &PageOptions) -> Result<String, String> {
     context.insert("title", options.title);
 
     render_template(
-        &fs::read_to_string("./template/template.html").unwrap(),
+        &fs::read_to_string(template_dir.join("template.html"))
+            .unwrap(),
         &context,
     )
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -111,7 +111,7 @@ pub fn render_template(
 ///
 pub fn render_page(
     options: &PageOptions,
-    template_dir: &Path,
+    template_path: &String,
 ) -> Result<String, String> {
     let mut context = HashMap::new();
     context.insert("content", options.content);
@@ -125,8 +125,10 @@ pub fn render_page(
     context.insert("title", options.title);
 
     render_template(
-        &fs::read_to_string(template_dir.join("template.html"))
-            .unwrap(),
+        &fs::read_to_string(
+            Path::new(template_path).join("template.html"),
+        )
+        .unwrap(),
         &context,
     )
 }
@@ -166,26 +168,93 @@ pub fn create_directory(path: &Path) -> io::Result<()> {
     })
 }
 
-/// Creates the template directory and downloads the template files.
-pub fn create_template_folder() -> Result<(), TemplateError> {
+/**
+ * Creates a template folder based on the provided template path or uses the default template folder
+ *
+ * If a URL is provided as the template path, the function downloads the template files to a temporary directory.
+ * If a local path is provided, the function uses it as the template directory path.
+ * If no path is provided, the function downloads the default template files to a temporary directory.
+ *
+ * # Arguments
+ *
+ * * `template_path` - An optional `&str` containing the path to the template folder
+ *
+ * # Returns
+ *
+ * Returns a `Result` that contains `()` if successful, or a `TemplateError` if an error occurs.
+ */
+pub fn create_template_folder(
+    template_path: Option<&String>,
+) -> Result<String, TemplateError> {
+    // Get the current working directory
     let current_dir = std::env::current_dir()?;
     println!("Current directory: {:?}", current_dir);
 
-    let template_dir_path = current_dir.join("template");
-    create_directory(&template_dir_path)?;
-    println!("Creating template directory: {:?}", template_dir_path);
+    // Determine the template directory path based on the provided argument or use the default path
+    let template_dir_path = match template_path {
+        Some(path) => {
+            if path.starts_with("http://")
+                || path.starts_with("https://")
+            {
+                // If a URL is provided, download the template files to a temporary directory
+                let tempdir = tempfile::tempdir()?;
+                let template_dir_path = tempdir.into_path().to_owned();
+                println!(
+                    "Creating temporary directory for template: {:?}",
+                    template_dir_path
+                );
 
-    let url = "https://raw.githubusercontent.com/sebastienrousseau/shokunin/main/template/";
-    let files = ["template.html", "template.json"];
+                let url = path;
+                let files = ["template.html", "template.json"];
 
-    for file in files.iter() {
-        let file_url = format!("{}{}", url, file);
-        let file_path = template_dir_path.join(file);
-        let mut download = reqwest::blocking::get(&file_url)?;
-        let mut file = File::create(&file_path)?;
-        download.copy_to(&mut file)?;
-        println!("Downloading template file: {}", file_url);
-    }
-    println!("Template directory created: {:?}", template_dir_path);
-    Ok(())
+                for file in files.iter() {
+                    let file_url = format!("{}/{}", url, file);
+                    let file_path = template_dir_path.join(file);
+                    let mut download =
+                        reqwest::blocking::get(&file_url)?;
+                    let mut file = File::create(&file_path)?;
+                    download.copy_to(&mut file)?;
+                    println!(
+                        "Downloaded template file to: {:?}",
+                        file_path
+                    );
+                }
+
+                template_dir_path
+            } else {
+                // If a local path is provided, use it as the template directory path
+                println!("Using local template directory: {}", path);
+                current_dir.join(path)
+            }
+        }
+        None => {
+            // If no path is provided, download the default template files to a temporary directory
+            let tempdir = tempfile::tempdir()?;
+            let template_dir_path = tempdir.into_path().to_owned();
+            println!(
+                "Creating temporary directory for default template: {:?}",
+                template_dir_path
+            );
+
+            let url = "https://raw.githubusercontent.com/sebastienrousseau/shokunin/main/template/";
+            let files = ["template.html", "template.json"];
+
+            for file in files.iter() {
+                let file_url = format!("{}/{}", url, file);
+                let file_path = template_dir_path.join(file);
+                let mut download = reqwest::blocking::get(&file_url)?;
+                let mut file = File::create(&file_path)?;
+                download.copy_to(&mut file)?;
+                println!(
+                    "Downloaded default template file to: {:?}",
+                    file_path
+                );
+            }
+
+            template_dir_path
+        }
+    };
+    println!("Template directory path: {:?}", template_dir_path);
+
+    Ok(String::from(template_dir_path.to_str().unwrap()))
 }


### PR DESCRIPTION
This change allows the user to define a template directory as argument as suggested in #14:
```
ssg --new=my-site --template=template --content=content --output=output
```

I opened this PR as WIP, because i have a few questions:

1. Should i check the provided directory if an `index.html` file exists (because that is needed for generation)?
2. I have commented out the `create_template_folder` function. I'm wondering if i should make the argument not mandatory and default to the existing template if no template was provided?