### PR TITLE
Use 'new' instead of 'name' for the argument name in the error message

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -44,7 +44,7 @@ pub fn args(matches: &ArgMatches) -> Result<(), String> {
         Some(name) => name.to_owned(),
         None => {
             return Err(
-                "❌ Error: Argument \"name\" is required but missing."
+                "❌ Error: Argument \"new\" is required but missing."
                     .to_owned(),
             );
         }

--- a/tests/test_args.rs
+++ b/tests/test_args.rs
@@ -48,7 +48,7 @@
 //         // Assert that the function returns an error message.
 //         assert_eq!(
 //             result,
-//             Err("❌ Error: Argument \"name\" is required but missing."
+//             Err("❌ Error: Argument \"new\" is required but missing."
 //                 .to_owned())
 //         );
 

--- a/tests/test_parser.rs
+++ b/tests/test_parser.rs
@@ -14,7 +14,7 @@ mod tests {
         let result = args(&matches);
         assert_eq!(
             result,
-            Err("❌ Error: Argument \"name\" is required but missing."
+            Err("❌ Error: Argument \"new\" is required but missing."
                 .to_owned())
         );
     }


### PR DESCRIPTION
Just a wording thing. This fixes #39. 