### PR TITLE
docs(v0.0.38): README rewrite, 95% coverage, 10 Actions bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.38] - 2026-04-20
+
+### Added
+- **Agentic LLM pipeline**: `--ai-fix` CLI flag triggers audit, diagnose, fix, verify, and report cycle with configurable max refinement attempts and JSON output
+- **Multilingual readability**: Kandel-Moles (FR), Wiener Sachtextformel (DE), Gulpease (IT), LIX (SV/NO/DA), Fernandez Huerta (ES) with BCP 47 language detection from frontmatter
+- **OG image generation**: auto-generated SVG social cards from page title and site name, injected via `og:image` meta tag, zero new dependencies
+- **Scalability benchmarks**: Criterion benchmarks at 100, 1K, and 10K page tiers with CI job on release tags
+- **axe-core CI**: `@axe-core/playwright` integration for WCAG 2.1 AA audit with JSON report artifacts
+- **CSP whitepaper**: `docs/whitepaper/csp-without-compromise.md` documenting build-time inline extraction and SRI hashing
+- **237 new unit tests**: coverage raised from 94.24% to 95.06% regions (1,640 total)
+
+### Changed
+- CI coverage regions floor raised from 94% to 95%
+- Version bumped from 0.0.37 to 0.0.38
+- README rewritten with updated metrics, feature matrix, and architecture diagram
+
+### Fixed
+- `package-lock.json` synced with `@axe-core/playwright` dependency
+- axe-core a11y audit restricted to desktop project (Chromium only) to avoid missing WebKit binary in CI
+
+### Dependencies
+- `actions/checkout` v4 to v6.0.2
+- `actions/download-artifact` v4 to v8.0.1
+- `actions/attest-build-provenance` v2 to v4.1.0
+- `actions/upload-pages-artifact` v3 to v5.0.0
+- `actions/deploy-pages` v4 to v5.0.0
+- `actions/cache` v4 to v5.0.5
+- `actions/setup-node` v4 to v6.4.0
+- `docker/setup-buildx-action` v3 to v4.0.0
+- `docker/build-push-action` v6 to v7.1.0
+- `docker/login-action` v3 to v4.1.0
+
 ## [0.0.37] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">Static Site Generator (SSG)</h1>
 
 <p align="center">
-  <strong>Fast, memory-safe, and extensible — built in Rust.</strong>
+  <strong>AI-augmented, accessibility-first static site generator built in Rust.</strong>
 </p>
 
 <p align="center">
@@ -15,89 +15,55 @@
   <a href="https://crates.io/crates/ssg"><img src="https://img.shields.io/crates/v/ssg.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/ssg"><img src="https://img.shields.io/badge/docs.rs-ssg-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/static-site-generator"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/static-site-generator?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.37-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.38-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
 
 ## Contents
 
-- [Install](#install) — one-liner, Homebrew, Cargo, apt, AUR, Scoop, winget
-- [Quick Start](#quick-start) — scaffold a site in 30 seconds
-- [Overview](#overview) — what SSG does
-- [Architecture](#architecture) — build pipeline diagram
-- [Features](#features) — v0.0.37 capability matrix
-- [The CLI](#the-cli) — flags and usage
-- [Library Usage](#library-usage) — `ssg::run()`, plugins, schemas
-- [Benchmarks](#benchmarks) — binary size, test suite, coverage
-- [Development](#development) — make targets, contributing
-- [What's Included](#whats-included) — all 36 modules
+- [Install](#install) -- Cargo, Homebrew, apt, AUR, one-liner
+- [Quick Start](#quick-start) -- scaffold a site in 30 seconds
+- [Overview](#overview) -- what SSG does
+- [Architecture](#architecture) -- build pipeline diagram
+- [Benchmarks](#benchmarks) -- performance and test suite metrics
+- [Features](#features) -- v0.0.38 capability matrix
+- [The CLI](#the-cli) -- flags and usage
+- [Library Usage](#library-usage) -- plugins, schemas, AI pipeline
+- [Examples](#examples) -- 8 branded examples
+- [Development](#development) -- make targets, CI workflows
+- [Security](#security) -- safety guarantees and compliance
 - [License](#license)
 
 ---
 
 ## Install
 
-### Quick install (prebuilt binary)
-
-**macOS / Linux — one command:**
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/static-site-generator/main/scripts/install.sh | sh
-```
-
-Auto-detects your OS and architecture, downloads the correct binary from GitHub Releases, verifies the SHA256 checksum, and installs to `~/.local/bin`.
-
-**Homebrew (macOS / Linux):**
-
-```sh
-brew install --formula https://raw.githubusercontent.com/sebastienrousseau/static-site-generator/main/packaging/homebrew/ssg.rb
-```
-
-**Cargo (any platform with Rust):**
-
-```sh
-cargo install ssg
-```
-
-**Debian / Ubuntu (apt):**
-
-```sh
-# Download the .deb from the latest release, then:
-sudo dpkg -i ssg_0.0.37_amd64.deb
-```
-
-Or build it yourself with `packaging/deb/build.sh`.
-
-**Arch Linux (AUR):**
-
-```sh
-# Using an AUR helper (e.g. yay):
-yay -S ssg
-```
-
-Or build manually with the PKGBUILD in `packaging/arch/`.
-
-**Windows (Scoop):**
-
-```powershell
-scoop bucket add ssg https://github.com/sebastienrousseau/static-site-generator
-scoop install ssg
-```
-
-**Windows (winget):**
-
-```powershell
-winget install sebastienrousseau.ssg
-```
-
-**Windows (manual):** download the `.zip` from the [latest release](https://github.com/sebastienrousseau/static-site-generator/releases/latest), extract `ssg.exe`, and add it to your `PATH`.
-
-### Use as a library
-
 ```toml
 [dependencies]
-ssg = "0.0.37"
+ssg = "0.0.38"
+```
+
+### Prebuilt binaries
+
+```sh
+# macOS / Linux -- one command
+curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/static-site-generator/main/scripts/install.sh | sh
+
+# Homebrew
+brew install --formula https://raw.githubusercontent.com/sebastienrousseau/static-site-generator/main/packaging/homebrew/ssg.rb
+
+# Cargo
+cargo install ssg
+
+# Debian / Ubuntu
+sudo dpkg -i ssg_0.0.38_amd64.deb
+
+# Arch Linux (AUR)
+yay -S ssg
+
+# Container
+docker pull ghcr.io/sebastienrousseau/static-site-generator:latest
 ```
 
 ### Build from source
@@ -105,45 +71,45 @@ ssg = "0.0.37"
 ```bash
 git clone https://github.com/sebastienrousseau/static-site-generator.git
 cd static-site-generator
-make init    # installs toolchain, hooks, builds
-cargo test --lib
+make          # check + clippy + test
 ```
 
-Requires **Rust 1.88.0+** (pinned in `rust-toolchain.toml`).
+Requires **Rust 1.88.0+**. Tested on Linux, macOS, and Windows.
 
 ---
 
 ## Quick Start
 
 ```bash
-# 1 — Install
+# 1 -- Install
 cargo install ssg
 
-# 2 — Scaffold a new site
+# 2 -- Scaffold a new site
 ssg -n mysite -c content -o build -t templates
 
-# 3 — Build with custom content
+# 3 -- Build
 ssg -c content -o public -t templates
 
-# 4 — Validate content schemas (no build)
-ssg --validate -c content
+# 4 -- Development server with live reload
+ssg -c content -o public -t templates -s public -w
 
-# 5 — Development server
-ssg -c content -o public -t templates -s public
+# 5 -- AI-powered readability fix (requires Ollama)
+ssg -c content -o public -t templates --ai-fix
 ```
 
 ---
 
 ## Overview
 
-SSG generates static websites from Markdown content, YAML frontmatter, and HTML templates. It compiles everything into production-ready HTML with built-in SEO metadata, accessibility compliance, and feed generation. The plugin system handles the rest.
+SSG generates static websites from Markdown content, YAML frontmatter, and `MiniJinja` templates. It compiles everything into production-ready HTML with built-in SEO metadata, WCAG 2.1 AA accessibility compliance, multilingual readability scoring, and feed generation. The 33-plugin pipeline handles the rest.
 
-- **Zero-cost performance** — Rust ownership model, Rayon-parallelised plugins
-- **Incremental builds** — content fingerprinting via `.ssg-cache.json`
-- **File watching** — automatic rebuild on content changes
-- **22-plugin pipeline** — SEO, a11y, i18n, search, images, JSON-LD, RSS, sitemaps
-- **WCAG 2.1 Level AA** — accessibility compliance validated on every build
-- **Lighthouse 100** — SEO and accessibility scores on generated output
+- **33-plugin pipeline** -- SEO, a11y, i18n, search, images, AI, CSP, JSON-LD, RSS, sitemaps
+- **Agentic AI pipeline** -- audit, diagnose, fix, and verify content readability via local LLM
+- **Multilingual readability** -- Flesch-Kincaid (EN), Kandel-Moles (FR), Wiener Sachtextformel (DE), Gulpease (IT), LIX (SV), Fernandez Huerta (ES)
+- **Incremental builds** -- content fingerprinting via FNV-1a hashing and dependency graph
+- **Streaming compilation** -- configurable memory budgets for 100K+ page sites
+- **WCAG 2.1 AA** -- accessibility compliance validated on every build with axe-core CI
+- **Zero unsafe code** -- `#![forbid(unsafe_code)]` across the entire codebase
 
 ---
 
@@ -153,15 +119,42 @@ SSG generates static websites from Markdown content, YAML frontmatter, and HTML 
 graph TD
     A[Content: Markdown + YAML] --> B{SSG CLI}
     B --> V[Content Schema Validation]
-    V --> C[Incremental Cache]
+    V --> C[Incremental Cache + `DepGraph`]
     C --> D[Compile: staticdatagen]
     D --> E[Post-Processing Fixes]
-    E --> F[Plugin Pipeline: 22 plugins]
-    F --> G[Output: HTML + RSS + Sitemap + JSON-LD]
-    B --> H[File Watcher]
+    E --> F[Fused Transform Pipeline: 33 plugins]
+    F --> G[Output: HTML + RSS + Atom + Sitemap + JSON-LD]
+    B --> H[File Watcher + CSS HMR]
     H -->|changed files| C
-    B -->|--serve| S[Dev Server + Live Reload]
+    B -->|--serve| S[Dev Server + Live Reload + Error Overlay]
+    B -->|--ai-fix| AI[Agentic LLM Pipeline]
+    AI -->|audit + fix| A
 ```
+
+---
+
+## Benchmarks
+
+| Metric | Value |
+| :--- | :--- |
+| **Source** | 39,103 lines across 38 modules |
+| **Test suite** | 1,640 unit tests + 14 integration test suites |
+| **Coverage** | 95% region, 97% line, 96% function |
+| **Plugin pipeline** | 33 plugins, Rayon-parallelised |
+| **Examples** | 8 branded examples |
+| **Dependencies** | 15 runtime |
+| **MSRV** | Rust 1.88.0 |
+
+### Build performance
+
+| Pages | Time | Memory |
+|-------|------|--------|
+| 100 | < 5s (CI-gated) | < 100 MB |
+| 1,000 | < 10s | < 200 MB |
+| 10,000 | Streaming batches | 512 MB budget |
+| 100,000+ | Streaming compilation | Configurable via `--max-memory` |
+
+Reproduce: `cargo bench --bench bench -- scalability`.
 
 ---
 
@@ -169,39 +162,36 @@ graph TD
 
 | | |
 | :--- | :--- |
-| **Performance** | Parallel file operations with Rayon `par_iter`, iterative traversal with depth bounds, incremental builds, `--jobs N` thread control |
-| **Content** | Markdown with GFM extensions (tables, strikethrough, task lists), YAML/TOML/JSON frontmatter, typed content schemas with compile-time validation |
-| **SEO** | Meta description, Open Graph (title, description, type, url, image, image:width/height, locale), Twitter Cards (`summary_large_image` for articles), canonical URLs, robots.txt, sitemaps with per-page lastmod |
-| **Structured Data** | JSON-LD Article/WebPage with datePublished, dateModified, author (Person entity), image (`ImageObject`), inLanguage, `BreadcrumbList` |
-| **Syndication** | RSS 2.0 with enclosures, categories, language, lastBuildDate, copyright. Google News sitemap with keywords |
-| **Accessibility** | Automatic WCAG 2.1 AA validation on every build. Decorative image detection (`role="presentation"`). Heading hierarchy, link text, ARIA landmarks |
-| **i18n** | Hreflang injection for multi-locale sites, `x-default` support, per-locale sitemaps with `xhtml:link` alternates, language switcher HTML helper |
-| **Images** | Responsive `<picture>` with AVIF/WebP sources, `srcset` at 320/640/1024/1440, lazy loading, CLS prevention via width/height from source metadata |
-| **Templates** | Tera engine with inheritance, loops, conditionals, custom filters. 7 bundled templates + 3 themes (minimal, docs, full) |
-| **Search** | Client-side full-text search with modal UI, 28 locale translations, `Ctrl+K` / `⌘K` shortcut |
-| **Plugins** | Lifecycle hooks: `before_compile`, `after_compile`, `on_serve`. 22 built-in plugins |
-| **Deployment** | One-command config for Netlify, Vercel, Cloudflare Pages, GitHub Pages. CSP + HSTS security headers |
-| **Security** | `#![forbid(unsafe_code)]`, path traversal prevention, symlink rejection, file size limits, `CycloneDX` SBOM, Sigstore attestation |
-| **CI** | Automated multi-platform releases (Linux glibc/musl, macOS ARM64/Intel, Windows), pa11y accessibility audits, cargo audit/deny |
-| **WebAssembly** | ssg-core + ssg-wasm compile to WASM for browser/edge |
-| **Interactive Islands** | Web Components with lazy hydration (visible, idle, interaction) |
-| **CSS Hot Reload** | Stylesheet changes apply without full page reload |
-| **Browser Error Overlay** | Build errors render in-browser via WebSocket |
-| **Incremental Rebuilds** | Dependency graph tracks page → template relationships |
-| **95% Coverage Floors** | Regions, lines, and functions enforced in CI |
+| **Performance** | Parallel file operations with Rayon, fused single-pass HTML transforms, content-addressed caching (FNV-1a), dependency graph for incremental rebuilds, streaming compilation for 100K+ pages, `--jobs N` thread control, `--max-memory MB` budget |
+| **AI Pipeline** | Agentic LLM pipeline (`--ai-fix`): audit content readability, diagnose failing files, generate fixes via local LLM (Ollama), verify improvement, produce JSON report. Dry-run mode (`--ai-fix-dry-run`). Auto-generate alt text, meta descriptions, and JSON-LD via LLM |
+| **Readability** | Multilingual scoring: Flesch-Kincaid (EN), Kandel-Moles (FR), Wiener Sachtextformel (DE), Gulpease (IT), LIX (SV/NO/DA), Fernandez Huerta (ES). BCP 47 language detection from frontmatter. CI readability gate |
+| **Content** | Markdown with GFM extensions (tables, strikethrough, task lists), YAML/TOML/JSON frontmatter, typed content schemas with compile-time validation, shortcodes (youtube, gist, figure, admonition) |
+| **SEO** | Meta description, Open Graph (title, description, type, url, image, locale), auto-generated OG social cards (SVG), Twitter Cards, canonical URLs, robots.txt, sitemaps with per-page lastmod |
+| **Structured Data** | JSON-LD Article/WebPage with datePublished, dateModified, author, image, inLanguage, `BreadcrumbList` |
+| **Syndication** | RSS 2.0 with enclosures and categories, Atom 1.0, Google News sitemap |
+| **Accessibility** | WCAG 2.1 AA validation on every build, axe-core Playwright CI, decorative image detection, heading hierarchy, ARIA landmarks |
+| **i18n** | Hreflang injection, `x-default` support, per-locale sitemaps, language switcher HTML |
+| **Images** | Responsive `<picture>` with WebP sources, `srcset` at 320/640/1024/1440, lazy loading, CLS prevention |
+| **Templates** | `MiniJinja` engine with inheritance, loops, conditionals, custom filters |
+| **Search** | Client-side full-text search with modal UI, 28 locale translations, `Ctrl+K` / `Cmd+K` |
+| **Security** | CSP build-time extraction (zero `unsafe-inline`), SRI hash generation, asset fingerprinting, path traversal prevention |
+| **DX** | CSS hot reload, browser error overlay via WebSocket, file watching with change classification |
+| **WebAssembly** | ssg-core + ssg-wasm compile to `wasm32-unknown-unknown` with wasm-bindgen |
+| **Islands** | Web Components with lazy hydration (visible, idle, interaction) |
 
 ### Why SSG?
 
 | Capability | SSG | Hugo | Zola | Astro |
 |---|---|---|---|---|
-| Built-in WCAG validation | ✓ | ✗ | ✗ | ✗ |
-| CSP/SRI auto-extraction | ✓ | ✗ | ✗ | ✓ |
-| Local LLM integration | ✓ | ✗ | ✗ | ✗ |
-| WebAssembly target | ✓ | ✗ | ✗ | N/A |
-| 95% CI coverage floors | ✓ | ✗ | ✗ | ✗ |
-| Property-based testing | ✓ | ✗ | ✗ | ✗ |
-| Readability CI gate | ✓ | ✗ | ✗ | ✗ |
-| Zero unsafe code | ✓ | ✓ | ✓ | N/A |
+| Agentic AI pipeline | Yes | No | No | No |
+| Multilingual readability | Yes | No | No | No |
+| Auto-generated OG images | Yes | No | No | Plugin |
+| Built-in WCAG validation | Yes | No | No | No |
+| CSP/SRI auto-extraction | Yes | No | No | Plugin |
+| axe-core CI gate | Yes | No | No | No |
+| WebAssembly target | Yes | No | No | N/A |
+| 95% CI coverage floors | Yes | No | No | No |
+| Zero unsafe code | Yes | Yes | Yes | N/A |
 
 ---
 
@@ -211,43 +201,43 @@ graph TD
 Usage: ssg [OPTIONS]
 
 Options:
-  -f, --config <FILE>    Configuration file path
-  -n, --new <NAME>       Create new project
-  -c, --content <DIR>    Content directory
-  -o, --output <DIR>     Output directory
-  -t, --template <DIR>   Template directory
-  -s, --serve <DIR>      Start development server
-  -w, --watch            Watch for changes and rebuild
-  -j, --jobs <N>         Rayon thread count (default: num_cpus)
-      --validate         Validate content schemas and exit
-      --drafts           Include draft pages in the build
-      --deploy <TARGET>  Generate deployment config (netlify, vercel, cloudflare, github)
-  -q, --quiet            Suppress non-error output
-      --verbose          Show detailed build information
-  -h, --help             Print help
-  -V, --version          Print version
+  -f, --config <FILE>      Configuration file path
+  -n, --new <NAME>         Create new project
+  -c, --content <DIR>      Content directory
+  -o, --output <DIR>       Output directory
+  -t, --template <DIR>     Template directory
+  -s, --serve <DIR>        Start development server
+  -w, --watch              Watch for changes and rebuild
+  -j, --jobs <N>           Rayon thread count (default: num_cpus)
+      --max-memory <MB>    Peak memory budget for streaming (default: 512)
+      --ai-fix             Run agentic AI pipeline to fix content readability
+      --ai-fix-dry-run     Preview AI fixes without writing changes
+      --validate           Validate content schemas and exit
+      --drafts             Include draft pages in the build
+      --deploy <TARGET>    Generate deployment config (netlify, vercel, cloudflare, github)
+  -q, --quiet              Suppress non-error output
+      --verbose            Show detailed build information
+  -h, --help               Print help
+  -V, --version            Print version
 ```
-
-### Environment variables
-
-| Variable | Default | Purpose |
-| :--- | :--- | :--- |
-| `SSG_HOST` | `127.0.0.1` | Dev server bind address (use `0.0.0.0` for WSL2/Codespaces) |
-| `SSG_PORT` | `3000` | Dev server port |
 
 ---
 
 ## Library Usage
 
+<details>
+<summary><b>Minimal pipeline</b></summary>
+
 ```rust,no_run
-// The simplest path: delegate to ssg's own pipeline.
 fn main() -> anyhow::Result<()> {
     ssg::run()
 }
 ```
 
+</details>
+
 <details>
-<summary><b>Plugin example</b></summary>
+<summary><b>Custom plugin</b></summary>
 
 ```rust,no_run
 use ssg::plugin::{Plugin, PluginContext, PluginManager};
@@ -313,127 +303,152 @@ Pages with `schema = "post"` in their frontmatter are validated at compile time.
 </details>
 
 <details>
-<summary><b>Incremental build example</b></summary>
+<summary><b>Readability audit</b></summary>
 
 ```rust,no_run
-use ssg::cache::BuildCache;
+use ssg::llm::{LlmPlugin, LlmConfig};
 use std::path::Path;
 
-let cache_path = Path::new(".ssg-cache.json");
-let content_dir = Path::new("content");
+let report = LlmPlugin::audit_all(Path::new("content"), 8.0).unwrap();
+println!("{}/{} files pass grade 8.0", report.passing, report.total_files);
 
-let mut cache = BuildCache::load(cache_path).unwrap();
-let changed = cache.changed_files(content_dir).unwrap();
+// Multilingual: French content uses Kandel-Moles automatically
+// when frontmatter contains `language: fr`
+```
 
-if changed.is_empty() {
-    println!("No changes detected, skipping build.");
-} else {
-    println!("Rebuilding {} changed files", changed.len());
-    cache.update(content_dir).unwrap();
-    cache.save().unwrap();
-}
+</details>
+
+<details>
+<summary><b>OG image generation</b></summary>
+
+```rust,no_run
+use ssg::og_image::generate_og_svg;
+
+let svg = generate_og_svg("My Page Title", "My Site", "#1a1a2e", "#ffffff");
+std::fs::write("og-card.svg", svg).unwrap();
+// 1200x630 SVG social card ready for og:image
 ```
 
 </details>
 
 ---
 
-## Benchmarks
+## Examples
 
-| Metric | Value |
+Run any example:
+
+```bash
+cargo run --example basic
+cargo run --example blog
+```
+
+| Example | Purpose |
 | :--- | :--- |
-| **Release binary** | ~23 MB stripped with LTO |
-| **Unsafe code** | 0 blocks — `#![forbid(unsafe_code)]` enforced |
-| **Test suite** | **848 lib** + 34 doc tests |
-| **Dependencies** | 21 direct (down from 25 in v0.0.35) |
-| **Coverage** | ~98 % line coverage |
-| **Plugin pipeline** | 22 plugins, Rayon-parallelised |
-| **Build** | `cargo build`: ~2 min cold, <10 s incremental |
-| **MSRV** | Rust 1.88.0 |
-
-### Build Performance
-
-| Pages | Time | Memory |
-|-------|------|--------|
-| 50 | ~40ms | < 50 MB |
-| 100 | < 5s (CI-gated) | < 100 MB |
-| 10,000 | Streaming batches | 512 MB budget |
-| 100,000+ | Streaming compilation | Configurable |
+| `basic` | Minimal site with SEO, search, and fused transforms |
+| `quickstart` | Scaffold and build in 10 lines |
+| `multilingual` | Multi-locale site with hreflang and per-locale sitemaps |
+| `plugins` | Full plugin pipeline demo with `DepGraph` API |
+| `blog` | EAA-compliant accessibility-first blog with dual feeds |
+| `docs` | Documentation portal with schema validation and syntax highlighting |
+| `landing` | Zero-JS landing page with CSP hardening |
+| `portfolio` | Developer portfolio with JSON-LD and Atom feed |
 
 ---
 
 ## Development
 
 ```bash
-make init         # Bootstrap (rustfmt + clippy + cargo-deny + hooks + build)
-make build        # Build the project
-make test         # Run all tests
-make bench        # Run Criterion benchmarks
-make lint         # Lint with Clippy
-make format       # Format with rustfmt
-make deny         # Check licenses and advisories
-make doc          # Generate API docs and open in browser
-make a11y         # Run pa11y accessibility audit on example site
-make clean        # Remove build artifacts and stray logs
-make hooks        # Install the signed-commit git hook
+make              # check + clippy + test
+make test         # run all tests
+make bench        # run Criterion benchmarks
+make lint         # lint with Clippy
+make format       # format with rustfmt
+make deny         # supply-chain audit
+make doc          # build API documentation
+make a11y         # run pa11y accessibility audit
+make clean        # remove build artifacts
 ```
+
+### CI
+
+| Workflow | Trigger | Purpose |
+| :--- | :--- | :--- |
+| `ci.yml` | push, PR | fmt, clippy, test (3 OS), coverage (95% floor), cargo-deny |
+| `document.yml` | push to main | Build and deploy API docs to GitHub Pages |
+| `release.yml` | tag `v*` | Cross-platform binaries, GHCR container, crates.io, AUR |
+| `scheduled.yml` | weekly, tag | Multi-OS portability, pa11y a11y, `CycloneDX` SBOM, benchmarks |
+| `visual.yml` | PR | Playwright screenshots (3 viewports) + axe-core WCAG 2.1 AA |
+| `wasm.yml` | push, PR | Build and test ssg-core + ssg-wasm for wasm32 |
+| `readability-gate.yml` | PR | Flesch-Kincaid audit on docs and content |
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for signed commits and PR guidelines.
 
 ---
 
-## What's Included
+## Security
 
 <details>
-<summary><b>All 36 modules</b></summary>
+<summary><b>Safety guarantees and compliance</b></summary>
 
-| Module | Purpose |
-| :--- | :--- |
-| **cmd** | CLI argument parsing, `SsgConfig`, input validation |
-| **process** | Directory creation and site processing |
-| **lib** | Orchestrator: `run()` → pipeline → compile → serve |
-| **plugin** | `Plugin` trait with lifecycle hooks |
-| **plugins** | `MinifyPlugin`, `ImageOptiPlugin`, `DeployPlugin` |
-| **postprocess** | `SitemapFixPlugin`, `NewsSitemapFixPlugin`, `RssAggregatePlugin`, `ManifestFixPlugin`, `HtmlFixPlugin` |
-| **seo** | `SeoPlugin`, `JsonLdPlugin`, `CanonicalPlugin`, `RobotsPlugin` |
-| **content** | `ContentSchema`, `ContentValidationPlugin`, `--validate` |
-| **i18n** | `I18nPlugin`, hreflang injection, per-locale sitemaps |
-| **search** | Full-text index, search UI, 28 locale translations |
-| **accessibility** | WCAG checker, ARIA validation, decorative image detection |
-| **`image_plugin`** | `<picture>` with AVIF/WebP, responsive srcset |
-| **ai** | AI-readiness hooks, alt-text validation, `llms.txt` |
-| **deploy** | Netlify, Vercel, Cloudflare Pages, GitHub Pages adapters |
-| **assets** | Asset fingerprinting and SRI hash generation |
-| **highlight** | Syntax highlighting for code blocks |
-| **shortcodes** | youtube, gist, figure, admonition expansion |
-| **`markdown_ext`** | GFM tables, strikethrough, task lists |
-| **livereload** | WebSocket live-reload injection (dev only) |
-| **pagination** | Pagination plugin for listing pages |
-| **taxonomy** | Tag and category index generation |
-| **drafts** | Draft content filtering |
-| **frontmatter** | Frontmatter extraction and `.meta.json` sidecars |
-| **`tera_engine`** | Tera templating engine integration |
-| **`tera_plugin`** | Tera template rendering plugin |
-| **cache** | Content fingerprinting for incremental builds |
-| **watch** | Polling-based file watcher |
-| **schema** | JSON Schema generator for configuration |
-| **scaffold** | Project scaffolding (`ssg --new`) |
-| **stream** | High-performance streaming file processor |
-| **walk** | Shared bounded directory walkers |
+- `#![forbid(unsafe_code)]` across the entire codebase
+- CSP build-time extraction: all inline styles and scripts moved to external files with SRI hashes. Zero `unsafe-inline`
+- Path traversal prevention with `..` detection and symlink rejection
+- File size limits and directory depth bounds
+- `cargo audit` with zero advisories
+- `cargo deny` -- license, advisory, ban, and source checks
+- `CycloneDX` SBOM generated as release artifact with Sigstore attestation
+- SPDX license headers on all source files
+- Signed commits enforced via SSH ED25519
+
+See [docs/whitepaper/csp-without-compromise.md](docs/whitepaper/csp-without-compromise.md) for the full CSP security architecture.
 
 </details>
 
 <details>
-<summary><b>Security and compliance</b></summary>
+<summary><b>All 38 modules</b></summary>
 
-- `#![forbid(unsafe_code)]` across the entire codebase
-- Path traversal prevention with `..` detection and symlink rejection
-- File size limits (10 MB per file) and directory depth bounds (128 levels)
-- `cargo audit` with zero warnings
-- `cargo deny` — license, advisory, ban, and source checks
-- `CycloneDX` SBOM generated as release artifact with Sigstore attestation
-- SPDX license headers on all source files
-- Signed commits enforced via SSH ED25519
+| Module | Purpose |
+| :--- | :--- |
+| `accessibility` | WCAG 2.1 AA checker, ARIA validation, decorative image detection |
+| `ai` | AI-readiness hooks, alt-text validation, `llms.txt` / `llms-full.txt` generation |
+| `assets` | Asset fingerprinting and SRI hash generation |
+| `cache` | Content fingerprinting (FNV-1a) for incremental builds |
+| `cmd` | CLI argument parsing, `SsgConfig`, input validation |
+| `content` | Content schemas, `ContentValidationPlugin`, `--validate` |
+| `csp` | CSP build-time extraction of inline styles/scripts to external files |
+| `depgraph` | Page-to-template dependency graph for incremental rebuilds |
+| `deploy` | Netlify, Vercel, Cloudflare Pages, GitHub Pages adapters |
+| `drafts` | Draft content filtering |
+| `frontmatter` | Frontmatter extraction and `.meta.json` sidecars |
+| `fs_ops` | Safe file operations with traversal prevention |
+| `highlight` | Syntax highlighting for code blocks |
+| `i18n` | Hreflang injection, per-locale sitemaps, language switcher |
+| `image_plugin` | Responsive `<picture>` with WebP, srcset generation |
+| `islands` | Web Components with lazy hydration |
+| `livereload` | WebSocket live-reload, CSS HMR, browser error overlay |
+| `llm` | Local LLM pipeline (Ollama), multilingual readability scoring, agentic fix |
+| `logging` | Structured logging configuration |
+| `markdown_ext` | GFM tables, strikethrough, task lists |
+| `og_image` | Auto-generated OG social card SVGs |
+| `pagination` | Pagination plugin for listing pages |
+| `pipeline` | Build orchestration, plugin registration, `RunOptions` |
+| `plugin` | `Plugin` trait with lifecycle hooks, `PluginManager`, `PluginCache` |
+| `plugins` | `MinifyPlugin`, `ImageOptiPlugin`, `DeployPlugin` |
+| `postprocess` | Sitemap, RSS, Atom, manifest, HTML post-processing fixes |
+| `process` | Directory creation and site processing |
+| `scaffold` | Project scaffolding (`ssg --new`) |
+| `schema` | JSON Schema generator for configuration |
+| `search` | Full-text search index, modal UI, 28 locale translations |
+| `seo` | `SeoPlugin`, `JsonLdPlugin`, `CanonicalPlugin`, `RobotsPlugin` |
+| `server` | Development HTTP server |
+| `shortcodes` | youtube, gist, figure, admonition expansion |
+| `stream` | High-performance streaming file processor |
+| `streaming` | Memory-budgeted streaming compilation for large sites |
+| `taxonomy` | Tag and category index generation |
+| `template_engine` | `MiniJinja` templating engine integration |
+| `template_plugin` | `MiniJinja` template rendering plugin |
+| `walk` | Shared bounded directory walkers |
+| `watch` | Polling-based file watcher with change classification |
 
 </details>
 


### PR DESCRIPTION
## Summary

Post-merge follow-up for v0.0.38:

- **README rewritten** to match noyalib reference style: contents index, badges, architecture diagram, benchmarks table, 33-plugin feature matrix, CLI reference with `--ai-fix`, library usage examples (plugins, schemas, readability audit, OG images)
- **CHANGELOG v0.0.38** entry with Added, Changed, Fixed, Dependencies sections
- **Rustdoc** automatically updated via `include_str!("../README.md")`
- **95% coverage** — 237 new unit tests (1,640 total), CI floor raised from 94% to 95%
- **10 GitHub Actions bumps** — second round of Dependabot consolidation (#480–#484)
- **CI fixes** — package-lock.json sync, axe-core restricted to Chromium-only desktop project

Closes #480, closes #481, closes #482, closes #483, closes #484

## Test plan
- [x] `cargo clippy --lib --all-features -- -D warnings` clean
- [x] `cargo doc --no-deps --all-features` builds successfully
- [x] 1,640 unit tests pass
- [x] 95.06% region coverage

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co