### PR TITLE
release: v0.0.41 — noyalib chain, dependabot sweep, SBOM-friendly lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
           [ "$ok" = "1" ]
       - name: Upload to Codecov
         if: always()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           files: coverage.lcov
           fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,14 +231,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           # ARM64 cross-compile via QEMU is too slow for CI; build

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -2,7 +2,7 @@
 
 # Benchmarks
 
-Reproducible performance measurements for SSG v0.0.40.
+Reproducible performance measurements for SSG v0.0.41.
 
 ## CI Performance Gates
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ammonia"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+dependencies = [
+ "cssparser 0.35.0",
+ "html5ever 0.35.0",
+ "maplit",
+ "tendril 0.4.3",
+ "url",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +147,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,12 +162,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -225,9 +238,6 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "bitvec"
@@ -243,11 +253,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -607,6 +617,27 @@ dependencies = [
 
 [[package]]
 name = "comrak"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ae8f3e7e3f3d424cbb33354fc36943d507327d210aa5794b0192f4be726c6d"
+dependencies = [
+ "bon",
+ "caseless",
+ "clap",
+ "entities",
+ "memchr",
+ "once_cell",
+ "regex",
+ "shell-words",
+ "slug",
+ "syntect",
+ "typed-arena",
+ "unicode_categories",
+ "xdg 2.5.2",
+]
+
+[[package]]
+name = "comrak"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321d20bf105b6871a49da44c5fbb93e90a7cd6178ea5a9fe6cbc1e6d4504bc5e"
@@ -630,23 +661,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.15.23"
+name = "comrak"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
+checksum = "aac0b255932a9cd52fbfd664b67957f9f2e095ae4711cb0e41b4e291edef94c2"
 dependencies = [
- "async-trait",
- "convert_case",
- "json5",
- "pathdiff",
- "ron",
- "rust-ini",
- "serde-untagged",
- "serde_core",
- "serde_json",
- "toml 1.1.2+spec-1.1.0",
- "winnow 1.0.3",
- "yaml-rust2 0.11.0",
+ "bon",
+ "caseless",
+ "clap",
+ "emojis",
+ "entities",
+ "finl_unicode",
+ "fmt2io",
+ "jetscii",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "rustc-hash 2.1.2",
+ "shell-words",
+ "smallvec",
+ "syntect",
+ "typed-arena",
+ "xdg 3.0.0",
 ]
 
 [[package]]
@@ -663,24 +698,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-str"
@@ -712,32 +733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "cow-utils"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,9 +740,9 @@ checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -797,6 +792,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,15 +820,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,25 +833,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "cssparser"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf 0.11.3",
- "smallvec",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -865,7 +846,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be934d936a0fbed5bcdc01042b770de1398bf79d0e192f49fa7faea0e99281e"
 dependencies = [
- "cssparser-macros",
+ "cssparser-macros 0.6.1",
  "dtoa-short",
  "itoa",
  "phf 0.11.3",
@@ -878,10 +859,36 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
 dependencies = [
- "cssparser-macros",
+ "cssparser-macros 0.6.1",
  "dtoa-short",
  "itoa",
  "phf 0.11.3",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+dependencies = [
+ "cssparser-macros 0.6.1",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.3",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros 0.7.0",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
  "smallvec",
 ]
 
@@ -899,6 +906,16 @@ name = "cssparser-macros"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -1065,6 +1082,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,11 +1110,12 @@ checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -1104,15 +1143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "dragonbox_ecma"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,23 +1165,6 @@ dependencies = [
 
 [[package]]
 name = "dtt"
-version = "0.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0f956d085fb3371b9ab70b662dc444d2ebc60e2963eed84f1fc3fb3f56549c"
-dependencies = [
- "lazy_static",
- "paste",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror 1.0.69",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "dtt"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d0ded54a7c92b3bbc6d8a6a5ae97f120caa634ab7ee49d0b20ac2041037e2d"
@@ -1167,16 +1180,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "ego-tree"
-version = "0.6.3"
+name = "dtt"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
+checksum = "300fa4cbe63b08446f74755c6cc002fb70e45bf50c32390f475d19b1ef23bc8e"
+dependencies = [
+ "pastey 0.2.3",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "version_check",
+]
 
 [[package]]
 name = "ego-tree"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -1250,30 +1277,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "envy"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "erased-serde"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
-dependencies = [
- "serde",
- "serde_core",
- "typeid",
-]
 
 [[package]]
 name = "errno"
@@ -1291,9 +1298,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc1cf9c4720703ea04d9eb4a191ac8e43b597805742e102fb7eaa4d9c3f5b27"
 dependencies = [
- "serde",
  "thiserror 2.0.18",
- "toml 0.8.23",
 ]
 
 [[package]]
@@ -1344,6 +1349,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "flate2"
@@ -1405,37 +1416,23 @@ dependencies = [
 
 [[package]]
 name = "frontmatter-gen"
-version = "0.0.2"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca687f7d05be18198951f3599b904cfd1897a6a9e7c1dff2c2ae84df2c62a68"
-dependencies = [
- "serde",
- "serde_json",
- "serde_yml",
- "thiserror 1.0.69",
- "tokio",
- "toml 0.8.23",
- "version_check",
-]
-
-[[package]]
-name = "frontmatter-gen"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ffa823be6d8f1edb3785ddf46d97558f51ea470874a04eb51c3bf37c7c73f5"
+checksum = "05ce7e5bf87bc3550840886b912ccefd0ef5188e69e750b121e19168192445c8"
 dependencies = [
  "anyhow",
  "env_logger",
+ "euxis-commons",
  "log",
+ "noyalib 0.0.8",
  "serde",
  "serde_json",
- "serde_yml",
  "simple_logger",
  "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
  "uuid",
  "version_check",
 ]
@@ -1457,16 +1454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,18 +1471,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,10 +1483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
- "futures-io",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1523,16 +1495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1562,9 +1524,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1588,25 +1552,6 @@ checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1644,10 +1589,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.12",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1655,6 +1596,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1676,15 +1619,6 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "hashlink"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
@@ -1699,17 +1633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hostname"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-link",
-]
-
-[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,38 +1643,16 @@ dependencies = [
 
 [[package]]
 name = "html-generator"
-version = "0.0.1"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4175259dd09b9a572073218f67a8d1a424d7d13922a422d73b49b204786ecf"
-dependencies = [
- "comrak 0.28.0",
- "frontmatter-gen 0.0.2",
- "lazy_static",
- "mdx-gen 0.0.1",
- "minify-html 0.15.0",
- "once_cell",
- "regex",
- "scraper 0.20.0",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 1.0.69",
- "tokio",
- "version_check",
-]
-
-[[package]]
-name = "html-generator"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962715f8883a18b15e9dad9de412294ed2edcf590847b0f9986d9127367a9beb"
+checksum = "996c5a71e1cf23548209a503067083647ff3e850f6fa49f5947abc66a3259de0"
 dependencies = [
  "cfg",
- "comrak 0.50.0",
+ "comrak 0.32.0",
  "lazy_static",
  "log",
- "mdx-gen 0.0.2",
- "minify-html 0.18.1",
+ "mdx-gen 0.0.1",
+ "minify-html 0.15.0",
  "once_cell",
  "regex",
  "scraper 0.22.0",
@@ -1764,17 +1665,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "html5ever"
-version = "0.27.0"
+name = "html-generator"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+checksum = "19ccffe0fe0548aef64a326edde299c50a806f77b7338281bc561f20a6ae8a2e"
 dependencies = [
+ "ammonia",
+ "comrak 0.50.0",
+ "getrandom 0.3.4",
+ "indexmap",
  "log",
- "mac",
- "markup5ever 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "mdx-gen 0.0.2",
+ "minify-html 0.18.1",
+ "noyalib 0.0.3",
+ "once_cell",
+ "pulldown-latex",
+ "regex",
+ "scraper 0.27.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "version_check",
 ]
 
 [[package]]
@@ -1786,54 +1698,28 @@ dependencies = [
  "log",
  "mac",
  "markup5ever 0.14.1",
- "match_token",
+ "match_token 0.1.0",
 ]
 
 [[package]]
-name = "http"
-version = "1.4.1"
+name = "html5ever"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
 dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-handle"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9146e09a9aace92963ea15b9f1b6fa0610bf704a96d053ecc9b49be301d8a091"
-dependencies = [
- "anyhow",
  "log",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "version_check",
+ "markup5ever 0.35.0",
+ "match_token 0.35.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -1853,86 +1739,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "httparse"
-version = "1.10.1"
+name = "http-handle"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "hyper"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "3cf34d328daadca2f19e07da47d9485568162ab9f6514cd7304580871205e8d9"
 dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
+ "crossbeam-channel",
+ "ctrlc",
+ "euxis-commons",
+ "log",
+ "memchr",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "version_check",
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.9"
+name = "hybrid-array"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2",
- "system-configuration",
- "tokio",
- "tower-service",
- "tracing",
- "windows-registry",
+ "typenum",
 ]
 
 [[package]]
@@ -2105,12 +1935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,34 +2031,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e770254dd7802184595b1d30da2a15cb72569e2aca2b177aef8d22eac8a693"
 
 [[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
-]
-
-[[package]]
 name = "langweave"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9f7ee4f988f9bdd5689ba32459826303f304162cf3f4b39faf759708a43efe"
+checksum = "96e0dc69b9de07e0b3b7d3135cd9f5345c21d875801b5d59f79f886cec7cb2e0"
 dependencies = [
- "anyhow",
  "async-trait",
- "env_logger",
- "lazy_static",
  "log",
  "once_cell",
  "regex",
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 1.0.69",
- "tokio",
+ "thiserror 2.0.18",
  "version_check",
  "whatlang",
 ]
@@ -2264,16 +2073,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "lightningcss"
 version = "1.0.0-alpha.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,7 +2092,7 @@ dependencies = [
  "lightningcss-derive",
  "parcel_selectors",
  "parcel_sourcemap",
- "pastey",
+ "pastey 0.1.1",
  "pathdiff",
  "rayon",
  "serde",
@@ -2353,18 +2152,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
-name = "markup5ever"
-version = "0.12.1"
+name = "maplit"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
-dependencies = [
- "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
- "tendril",
-]
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
@@ -2375,9 +2166,31 @@ dependencies = [
  "log",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
- "tendril",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+dependencies = [
+ "log",
+ "tendril 0.4.3",
+ "web_atoms 0.1.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril 0.5.0",
+ "web_atoms 0.2.5",
 ]
 
 [[package]]
@@ -2385,6 +2198,17 @@ name = "match_token"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "match_token"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2464,32 +2288,26 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "metadata-gen"
-version = "0.0.2"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864ed834296703867169c44c683ebbebaf474dcd23623ccf41a9754a8f409a6e"
+checksum = "9bdfc9095ce2b6a57ef0302307e0bfc0d9127f498a48f1a687ab60ed22cf1a15"
 dependencies = [
  "anyhow",
- "dtt 0.0.9",
- "quick-xml 0.39.4",
+ "dtt 0.0.10",
+ "noyalib 0.0.8",
+ "quick-xml 0.40.1",
  "regex",
- "scraper 0.22.0",
+ "scraper 0.27.0",
  "serde",
  "serde_json",
- "serde_yml",
  "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
  "version_check",
- "yaml-rust2 0.9.0",
+ "yaml-rust2",
 ]
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicov"
@@ -2618,23 +2436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2458,32 @@ name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "noyalib"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5dc50790bdee1e91bb3407f58b9529e0de45dc65f7ffb06b514ecdbbd579489"
+dependencies = [
+ "indexmap",
+ "memchr",
+ "rustc-hash 2.1.2",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "noyalib"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14057395c16a4230575c6f86bfa074db87e8458626d3e56b20c2454334a7e50c"
+dependencies = [
+ "indexmap",
+ "memchr",
+ "rustc-hash 2.1.2",
+ "serde",
+ "smallvec",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2774,9 +2601,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2798,12 +2625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
 name = "openssl-src"
 version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,25 +2635,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
  "openssl-src",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3284,6 +3095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3294,58 +3111,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2",
-]
-
-[[package]]
-name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_shared 0.10.0",
-]
 
 [[package]]
 name = "phf"
@@ -3370,16 +3135,6 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
-dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
-]
-
-[[package]]
-name = "phf_codegen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
@@ -3396,16 +3151,6 @@ checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
  "phf_generator 0.13.1",
  "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared 0.10.0",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -3456,20 +3201,11 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher 0.3.11",
-]
-
-[[package]]
-name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.3",
+ "siphasher",
 ]
 
 [[package]]
@@ -3478,7 +3214,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher 1.0.3",
+ "siphasher",
 ]
 
 [[package]]
@@ -3664,24 +3400,12 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
-dependencies = [
- "bitflags",
- "getopts",
- "memchr",
- "pulldown-cmark-escape",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
+ "getopts",
  "memchr",
  "pulldown-cmark-escape",
  "unicase",
@@ -3692,6 +3416,15 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "pulldown-latex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b8bc0583825170e3f560701d966dc2f0e3a16946da371e37d30d3ad7207fb7e"
+dependencies = [
+ "bumpalo",
+]
 
 [[package]]
 name = "pxfm"
@@ -3713,21 +3446,21 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -3856,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick 1.1.4",
  "memchr",
@@ -3879,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -3890,62 +3623,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3978,69 +3655,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "rlg"
-version = "0.0.8"
+name = "rss-gen"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c9c573404feef0bc7012c96506ce134ec2bf04cd943ddd5eb205ac4e3c880d"
+checksum = "b80bc3f61d3a43d92302b7d7b1bbc2db17b3f83eeae69f5ab87730829166f592"
 dependencies = [
- "config",
- "crossbeam-queue",
  "dtt 0.0.9",
- "envy",
  "euxis-commons",
- "hostname",
- "itoa",
  "log",
- "parking_lot",
- "regex",
- "ryu",
+ "quick-xml 0.40.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
- "tracing-core",
- "version_check",
-]
-
-[[package]]
-name = "ron"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
-dependencies = [
- "bitflags",
- "once_cell",
- "serde",
- "serde_derive",
- "typeid",
- "unicode-ident",
-]
-
-[[package]]
-name = "rss-gen"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de826a400568de2c3a99c64977559141a5485b73ae3a91cdaf51728a010ebd"
-dependencies = [
- "dtt 0.0.9",
- "log",
- "quick-xml 0.36.2",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
  "time",
  "url",
  "version_check",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
 ]
 
 [[package]]
@@ -4056,6 +3685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4066,39 +3704,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
-dependencies = [
- "once_cell",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -4135,35 +3740,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scraper"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90460b31bfe1fc07be8262e42c665ad97118d4585869de9345a84d501a9eaf0"
-dependencies = [
- "ahash 0.8.12",
- "cssparser 0.31.2",
- "ego-tree 0.6.3",
- "getopts",
- "html5ever 0.27.0",
- "once_cell",
- "selectors 0.25.0",
- "tendril",
-]
 
 [[package]]
 name = "scraper"
@@ -4177,7 +3757,37 @@ dependencies = [
  "html5ever 0.29.1",
  "precomputed-hash",
  "selectors 0.26.0",
- "tendril",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "scraper"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527e65d9d888567588db4c12da1087598d0f6f8b346cc2c5abc91f05fc2dffe2"
+dependencies = [
+ "cssparser 0.34.0",
+ "ego-tree 0.10.0",
+ "getopts",
+ "html5ever 0.29.1",
+ "precomputed-hash",
+ "selectors 0.26.0",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "scraper"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
+dependencies = [
+ "cssparser 0.37.0",
+ "ego-tree 0.11.0",
+ "getopts",
+ "html5ever 0.39.0",
+ "precomputed-hash",
+ "selectors 0.38.0",
+ "tendril 0.5.0",
 ]
 
 [[package]]
@@ -4187,48 +3797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "selectors"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
-dependencies = [
- "bitflags",
- "cssparser 0.31.2",
- "derive_more",
- "fxhash",
- "log",
- "new_debug_unreachable",
- "phf 0.10.1",
- "phf_codegen 0.10.0",
- "precomputed-hash",
- "servo_arc 0.3.0",
- "smallvec",
-]
-
-[[package]]
 name = "selectors"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4236,14 +3804,33 @@ checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
 dependencies = [
  "bitflags",
  "cssparser 0.34.0",
- "derive_more",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "new_debug_unreachable",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
  "precomputed-hash",
- "servo_arc 0.4.3",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags",
+ "cssparser 0.37.0",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash 2.1.2",
+ "servo_arc",
  "smallvec",
 ]
 
@@ -4276,33 +3863,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde-content"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3753ca04f350fa92d00b6146a3555e63c55388c9ef2e11e09bce2ff1c0b509c6"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "serde-untagged"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
-dependencies = [
- "erased-serde",
- "serde",
- "serde_core",
- "typeid",
 ]
 
 [[package]]
@@ -4368,33 +3934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
-]
-
-[[package]]
 name = "serial_test"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4421,15 +3960,6 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
-name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
@@ -4439,9 +3969,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4514,33 +4044,28 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sitemap-gen"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff9d5a3c04d8b3ea597323cd72107fb86825ffaa6a616d41b9bbe5650580610"
+checksum = "d2d75dfdcabff12eb2ae2d3af23d2cfc9c0ce3d8e66da83d4e9b35b88fbb63df"
 dependencies = [
  "clap",
- "dtt 0.0.8",
+ "dtt 0.0.9",
  "env_logger",
- "html-generator 0.0.1",
+ "euxis-commons",
+ "html-generator 0.0.3",
  "indicatif",
  "lazy_static",
  "log",
  "regex",
- "scraper 0.20.0",
+ "scraper 0.23.1",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "url",
@@ -4588,21 +4113,21 @@ dependencies = [
 
 [[package]]
 name = "ssg"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "anyhow",
  "base64",
  "clap",
  "criterion",
  "fail",
- "frontmatter-gen 0.0.5",
- "http-handle 0.0.4",
+ "frontmatter-gen",
+ "http-handle 0.0.5",
  "image",
  "log",
  "minijinja",
  "openssl",
  "proptest",
- "pulldown-cmark 0.13.4",
+ "pulldown-cmark",
  "rayon",
  "serde",
  "serde_json",
@@ -4621,10 +4146,10 @@ dependencies = [
 
 [[package]]
 name = "ssg-core"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "log",
- "pulldown-cmark 0.13.4",
+ "pulldown-cmark",
  "serde",
  "serde_json",
  "toml 1.1.2+spec-1.1.0",
@@ -4632,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-wasm"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "js-sys",
  "serde-wasm-bindgen",
@@ -4656,56 +4181,45 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "staticdatagen"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e1261be52af2ac6b5e11fd8091ca843aeac4894642541945997c5fd3b00de8"
+checksum = "e27435f8dd8ab685cef7d12b5405cf2c550ce488b5c3c4ac303462851e6ae0f3"
 dependencies = [
  "anyhow",
- "clap",
- "comrak 0.50.0",
- "dtt 0.0.9",
- "html-generator 0.0.4",
- "http-handle 0.0.2",
+ "comrak 0.52.0",
+ "html-generator 0.0.6",
+ "http-handle 0.0.4",
  "idna",
  "langweave",
  "log",
  "metadata-gen",
- "minify-html 0.18.1",
- "pulldown-cmark 0.12.2",
+ "pulldown-cmark",
  "quick-xml 0.39.4",
  "rayon",
  "regex",
- "rlg",
  "rss-gen",
  "serde",
  "serde_json",
  "sitemap-gen",
  "staticweaver",
- "tempfile",
  "thiserror 2.0.18",
  "time",
- "toml 1.1.2+spec-1.1.0",
  "url",
  "uuid",
  "version_check",
- "vrd",
  "xml-rs 1.0.0",
 ]
 
 [[package]]
 name = "staticweaver"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe8ba80aa11ee0ce9ddbfa60331612ea499486c802979368b89f17a4a31a168"
+checksum = "ae2a375c7a4feb15ddd81a7a68f093a82d4c8363cf9d1959102434f98f4b90bf"
 dependencies = [
+ "askama_escape",
  "fnv",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
  "tempfile",
- "thiserror 1.0.69",
- "version_check",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4722,6 +4236,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "string_cache_codegen"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4734,16 +4260,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -4765,15 +4297,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
 ]
 
 [[package]]
@@ -4810,27 +4333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4857,6 +4359,16 @@ checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
 dependencies = [
  "futf",
  "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
  "utf-8",
 ]
 
@@ -4978,15 +4490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5047,39 +4550,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -5163,51 +4633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
- "url",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5282,34 +4707,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unarray"
@@ -5375,12 +4782,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5418,9 +4819,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5453,24 +4854,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
 
 [[package]]
-name = "vrd"
-version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a508bb0b1488739a137cabf75d8e294f2b01295c75d7489c6c1dfb7feb7da301"
-dependencies = [
- "bitflags",
- "dtt 0.0.9",
- "rand 0.8.6",
- "rlg",
- "serde",
- "serde-big-array",
- "serde_json",
- "tokio",
- "uuid",
- "version_check",
-]
-
-[[package]]
 name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5493,15 +4876,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]
@@ -5677,6 +5051,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5684,12 +5082,11 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whatlang"
-version = "0.16.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "471d1c1645d361eb782a1650b1786a8fb58dd625e681a04c09f5ff7c8764a7b0"
+checksum = "f5e8f38b596e2a359b755342473520a99421e43658548c79489ee221b728c107"
 dependencies = [
- "hashbrown 0.14.5",
- "once_cell",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5728,44 +5125,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -5863,9 +5222,6 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"
@@ -6020,24 +5376,13 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust2"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1a1c0bc9823338a3bdf8c61f994f23ac004c6fa32c08cd152984499b445e8d"
-dependencies = [
- "arraydeque",
- "encoding_rs",
- "hashlink 0.9.1",
-]
-
-[[package]]
-name = "yaml-rust2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink 0.11.1",
+ "hashlink",
 ]
 
 [[package]]
@@ -6103,12 +5448,6 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "ssg"                            # The name of the library
-version = "0.0.40"                      # The version of the library
+version = "0.0.41"                      # The version of the library
 authors = ["SSG Contributors"]     # The authors of the library
 edition = "2021"                        # The edition of the library
 rust-version = "1.88.0"                 # Minimum supported Rust version (set by time-macros, staticdatagen, oxc_*)
@@ -137,22 +137,22 @@ proptest = "1"
 # Required dependencies for building and running the project.
 anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive", "cargo", "env"] }
-http-handle = "0.0.4"
+http-handle = "0.0.5"
 log = { version = "0.4.29", features = ["std"] }
 pulldown-cmark = { version = "0.13", default-features = false, features = ["html"] }
 rayon = "1.12.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-ssg-core = { path = "crates/ssg-core", version = "0.0.40" }
+ssg-core = { path = "crates/ssg-core", version = "0.0.41" }
 thiserror = "2"
-staticdatagen = "0.0.8"
+staticdatagen = "0.0.9"
 toml = "1.1.2"
 
 # Real cryptographic hashing for Subresource Integrity (issue #468 follow-up).
 # Replaces the previous FNV-1a placeholder that emitted invalid `sha256-`
 # integrity attributes. `sha2` is the de-facto standard SHA-2 implementation;
 # `base64` emits the canonical base64 encoding that browsers expect.
-sha2 = "0.10"
+sha2 = "0.11"
 base64 = "0.22"
 
 
@@ -163,7 +163,7 @@ minijinja = { version = "2", optional = true, features = ["loader"] }
 image = { version = "0.25", optional = true, default-features = false, features = ["jpeg", "png", "gif", "webp", "bmp", "tiff"] }
 
 # Owned crate for frontmatter parsing
-frontmatter-gen = "0.0.5"
+frontmatter-gen = "0.0.6"
 
 # Optional observability stack (issue #422). Both crates are
 # `optional = true` — they enter the build only when the `otel`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://crates.io/crates/ssg"><img src="https://img.shields.io/crates/v/ssg.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/ssg"><img src="https://img.shields.io/badge/docs.rs-ssg-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/static-site-generator"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/static-site-generator?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.40-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.41-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
@@ -27,7 +27,7 @@
 - [Overview](#overview) -- what SSG does
 - [Architecture](#architecture) -- build pipeline diagram
 - [Benchmarks](#benchmarks) -- performance and test suite metrics
-- [Features](#features) -- v0.0.40 capability matrix
+- [Features](#features) -- v0.0.41 capability matrix
 - [The CLI](#the-cli) -- flags and usage
 - [Library Usage](#library-usage) -- plugins, schemas, AI pipeline
 - [Examples](#examples) -- 8 branded examples
@@ -41,7 +41,7 @@
 
 ```toml
 [dependencies]
-ssg = "0.0.40"
+ssg = "0.0.41"
 ```
 
 ### Prebuilt binaries
@@ -57,7 +57,7 @@ brew install --formula https://raw.githubusercontent.com/sebastienrousseau/stati
 cargo install ssg
 
 # Debian / Ubuntu
-sudo dpkg -i ssg_0.0.40_amd64.deb
+sudo dpkg -i ssg_0.0.41_amd64.deb
 
 # Arch Linux (AUR)
 yay -S ssg

--- a/crates/ssg-core/Cargo.toml
+++ b/crates/ssg-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-core"
-version = "0.0.40"
+version = "0.0.41"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-wasm/Cargo.toml
+++ b/crates/ssg-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-wasm"
-version = "0.0.40"
+version = "0.0.41"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,9 @@
 # ISC: used by some transitive deps
 # BSD-2-Clause/BSD-3-Clause: used by some transitive deps
 # Unicode-3.0: used by unicode data crates
+# Unicode-DFS-2016: used by finl_unicode (transitive via comrak → staticdatagen);
+#   the old "Unicode License Agreement - Data Files and Software" for the Unicode
+#   data tables. OSI-approved. Predates Unicode-3.0; both are acceptable here.
 # Zlib: used by foldhash (OSI-approved, FSF-free, permissive)
 # CC0-1.0: used by tiny-keccak → const-random → dlv-list (public-domain dedication)
 allow = [
@@ -14,6 +17,7 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "Unicode-3.0",
+    "Unicode-DFS-2016",
     "MPL-2.0",
     "ISC",
     "BSL-1.0",

--- a/docs/guide/wcag-compliance.md
+++ b/docs/guide/wcag-compliance.md
@@ -305,7 +305,7 @@ on judgement calls, not hunting empty `alt=""` tags.
 
 ---
 
-*This guide reflects SSG v0.0.40. The build-time validator is
+*This guide reflects SSG v0.0.41. The build-time validator is
 defined in [`src/plugins/accessibility.rs`](../../src/plugins/accessibility.rs);
 runtime audit configuration is in
 [`tests/visual/a11y.spec.ts`](../../tests/visual/a11y.spec.ts).*

--- a/examples/templates/ar/contact.html
+++ b/examples/templates/ar/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ar/">الرئيسية</a><span>&gt;</span><span>اتصل بنا</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/ar/feature.html
+++ b/examples/templates/ar/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ar/">الرئيسية</a><span>&gt;</span><span>الميزات</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="التذييل">
     <div class="footer-inner">

--- a/examples/templates/ar/index.html
+++ b/examples/templates/ar/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="المحتوى الرئيسي">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="التذييل">
     <div class="footer-inner">

--- a/examples/templates/ar/page.html
+++ b/examples/templates/ar/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ar/">الرئيسية</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="التذييل">
     <div class="footer-inner">

--- a/examples/templates/ar/post.html
+++ b/examples/templates/ar/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>بواسطة {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="التذييل">

--- a/examples/templates/ar/template.html
+++ b/examples/templates/ar/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ar/">الرئيسية</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="التذييل">
     <div class="footer-inner">

--- a/examples/templates/bn/contact.html
+++ b/examples/templates/bn/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/bn/">হোম</a><span>&gt;</span><span>যোগাযোগ</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/bn/feature.html
+++ b/examples/templates/bn/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/bn/">হোম</a><span>&gt;</span><span>বৈশিষ্ট্যসমূহ</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="ফুটার">
     <div class="footer-inner">

--- a/examples/templates/bn/index.html
+++ b/examples/templates/bn/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="প্রধান বিষয়বস্তু">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="ফুটার">
     <div class="footer-inner">

--- a/examples/templates/bn/page.html
+++ b/examples/templates/bn/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/bn/">হোম</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="ফুটার">
     <div class="footer-inner">

--- a/examples/templates/bn/post.html
+++ b/examples/templates/bn/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>লেখক: {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="ফুটার">

--- a/examples/templates/bn/template.html
+++ b/examples/templates/bn/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/bn/">হোম</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="ফুটার">
     <div class="footer-inner">

--- a/examples/templates/contact.html
+++ b/examples/templates/contact.html
@@ -6,15 +6,15 @@
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/v1/favicon.ico" />
@@ -142,7 +142,7 @@ pre code{background:none;padding:0}
         <kbd>&#8984;K</kbd>
       </button>
       <div class="nav-links" id="navLinks">
-        {{navigation}}
+        {{!navigation}}
       </div>
       <div class="nav-controls">
         <div style="position:relative">
@@ -162,14 +162,14 @@ pre code{background:none;padding:0}
     </div>
   </nav>
   <div class="mobile-menu" id="mobileMenu" role="navigation" aria-label="Mobile navigation">
-    {{navigation}}
+    {{!navigation}}
     <!-- ssg:lang-switcher -->
   </div>
   <main id="main" class="content-wrap" aria-label="Main content">
     <div class="breadcrumb">
       <a href="/">Home</a><span>&gt;</span><span>Contact</span>
     </div>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/cs/contact.html
+++ b/examples/templates/cs/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/cs/">Dom&uring;</a><span>&gt;</span><span>Kontakt</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/cs/feature.html
+++ b/examples/templates/cs/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/cs/">Dom&uring;</a><span>&gt;</span><span>Funkce</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Pati&ccaron;ka">
     <div class="footer-inner">

--- a/examples/templates/cs/index.html
+++ b/examples/templates/cs/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Hlavn&iacute; obsah">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Pati&ccaron;ka">
     <div class="footer-inner">

--- a/examples/templates/cs/page.html
+++ b/examples/templates/cs/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/cs/">Dom&uring;</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Pati&ccaron;ka">
     <div class="footer-inner">

--- a/examples/templates/cs/post.html
+++ b/examples/templates/cs/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Od {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Pati&ccaron;ka">

--- a/examples/templates/cs/template.html
+++ b/examples/templates/cs/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/cs/">Dom&uring;</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Pati&ccaron;ka">
     <div class="footer-inner">

--- a/examples/templates/de/contact.html
+++ b/examples/templates/de/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/de/">Startseite</a><span>&gt;</span><span>Kontakt</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/de/feature.html
+++ b/examples/templates/de/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/de/">Startseite</a><span>&gt;</span><span>Funktionen</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Fu&szlig;zeile">
     <div class="footer-inner">

--- a/examples/templates/de/index.html
+++ b/examples/templates/de/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Hauptinhalt">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Fu&szlig;zeile">
     <div class="footer-inner">

--- a/examples/templates/de/page.html
+++ b/examples/templates/de/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/de/">Startseite</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Fu&szlig;zeile">
     <div class="footer-inner">

--- a/examples/templates/de/post.html
+++ b/examples/templates/de/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Von {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Fu&szlig;zeile">

--- a/examples/templates/de/template.html
+++ b/examples/templates/de/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/de/">Startseite</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Fu&szlig;zeile">
     <div class="footer-inner">

--- a/examples/templates/en/contact.html
+++ b/examples/templates/en/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/en/">Home</a><span>&gt;</span><span>Contact</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/en/feature.html
+++ b/examples/templates/en/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/en/">Home</a><span>&gt;</span><span>Features</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">
     <div class="footer-inner">

--- a/examples/templates/en/index.html
+++ b/examples/templates/en/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Main content">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">
     <div class="footer-inner">

--- a/examples/templates/en/page.html
+++ b/examples/templates/en/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/en/">Home</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">
     <div class="footer-inner">

--- a/examples/templates/en/post.html
+++ b/examples/templates/en/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>By {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">

--- a/examples/templates/en/template.html
+++ b/examples/templates/en/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/en/">Home</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">
     <div class="footer-inner">

--- a/examples/templates/es/contact.html
+++ b/examples/templates/es/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/es/">Inicio</a><span>&gt;</span><span>Contacto</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/es/feature.html
+++ b/examples/templates/es/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/es/">Inicio</a><span>&gt;</span><span>Funcionalidades</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Pie de página">
     <div class="footer-inner">

--- a/examples/templates/es/index.html
+++ b/examples/templates/es/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Contenido principal">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Pie de página">
     <div class="footer-inner">

--- a/examples/templates/es/page.html
+++ b/examples/templates/es/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/es/">Inicio</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Pie de página">
     <div class="footer-inner">

--- a/examples/templates/es/post.html
+++ b/examples/templates/es/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Por {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Pie de página">

--- a/examples/templates/es/template.html
+++ b/examples/templates/es/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/es/">Inicio</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Pie de página">
     <div class="footer-inner">

--- a/examples/templates/feature.html
+++ b/examples/templates/feature.html
@@ -6,15 +6,15 @@
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/v1/favicon.ico" />
@@ -142,7 +142,7 @@ pre code{background:none;padding:0}
         <kbd>&#8984;K</kbd>
       </button>
       <div class="nav-links" id="navLinks">
-        {{navigation}}
+        {{!navigation}}
       </div>
       <div class="nav-controls">
         <div style="position:relative">
@@ -162,14 +162,14 @@ pre code{background:none;padding:0}
     </div>
   </nav>
   <div class="mobile-menu" id="mobileMenu" role="navigation" aria-label="Mobile navigation">
-    {{navigation}}
+    {{!navigation}}
     <!-- ssg:lang-switcher -->
   </div>
   <main id="main" class="content-wrap" aria-label="Main content">
     <div class="breadcrumb">
       <a href="/">Home</a><span>&gt;</span><span>Features</span>
     </div>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">
     <div class="footer-inner">

--- a/examples/templates/fr/contact.html
+++ b/examples/templates/fr/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/fr/">Accueil</a><span>&gt;</span><span>Contact</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/fr/feature.html
+++ b/examples/templates/fr/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/fr/">Accueil</a><span>&gt;</span><span>Features</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Pied de page">
     <div class="footer-inner">

--- a/examples/templates/fr/index.html
+++ b/examples/templates/fr/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Contenu principal">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Pied de page">
     <div class="footer-inner">

--- a/examples/templates/fr/page.html
+++ b/examples/templates/fr/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/fr/">Accueil</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Pied de page">
     <div class="footer-inner">

--- a/examples/templates/fr/post.html
+++ b/examples/templates/fr/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Par {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Pied de page">

--- a/examples/templates/fr/template.html
+++ b/examples/templates/fr/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/fr/">Accueil</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Pied de page">
     <div class="footer-inner">

--- a/examples/templates/ha/contact.html
+++ b/examples/templates/ha/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ha/">Gida</a><span>&gt;</span><span>Tuntuba</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/ha/feature.html
+++ b/examples/templates/ha/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ha/">Gida</a><span>&gt;</span><span>Abubuwa</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Kasan shafi">
     <div class="footer-inner">

--- a/examples/templates/ha/index.html
+++ b/examples/templates/ha/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Babban abun ciki">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Kasan shafi">
     <div class="footer-inner">

--- a/examples/templates/ha/page.html
+++ b/examples/templates/ha/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ha/">Gida</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Kasan shafi">
     <div class="footer-inner">

--- a/examples/templates/ha/post.html
+++ b/examples/templates/ha/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Daga {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Kasan shafi">

--- a/examples/templates/ha/template.html
+++ b/examples/templates/ha/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ha/">Gida</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Kasan shafi">
     <div class="footer-inner">

--- a/examples/templates/he/contact.html
+++ b/examples/templates/he/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/he/">עמוד הבית</a><span>&gt;</span><span>צור קשר</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/he/feature.html
+++ b/examples/templates/he/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/he/">עמוד הבית</a><span>&gt;</span><span>תכונות</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="כותרת תחתונה">
     <div class="footer-inner">

--- a/examples/templates/he/index.html
+++ b/examples/templates/he/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="תוכן ראשי">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="כותרת תחתונה">
     <div class="footer-inner">

--- a/examples/templates/he/page.html
+++ b/examples/templates/he/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/he/">עמוד הבית</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="כותרת תחתונה">
     <div class="footer-inner">

--- a/examples/templates/he/post.html
+++ b/examples/templates/he/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>מאת {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="כותרת תחתונה">

--- a/examples/templates/he/template.html
+++ b/examples/templates/he/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/he/">עמוד הבית</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="כותרת תחתונה">
     <div class="footer-inner">

--- a/examples/templates/hi/contact.html
+++ b/examples/templates/hi/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/hi/">होम</a><span>&gt;</span><span>संपर्क</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/hi/feature.html
+++ b/examples/templates/hi/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/hi/">होम</a><span>&gt;</span><span>विशेषताएँ</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="फ़ुटर">
     <div class="footer-inner">

--- a/examples/templates/hi/index.html
+++ b/examples/templates/hi/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="मुख्य सामग्री">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="फ़ुटर">
     <div class="footer-inner">

--- a/examples/templates/hi/page.html
+++ b/examples/templates/hi/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/hi/">होम</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="फ़ुटर">
     <div class="footer-inner">

--- a/examples/templates/hi/post.html
+++ b/examples/templates/hi/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>लेखक: {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="फ़ुटर">

--- a/examples/templates/hi/template.html
+++ b/examples/templates/hi/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/hi/">होम</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="फ़ुटर">
     <div class="footer-inner">

--- a/examples/templates/id/contact.html
+++ b/examples/templates/id/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/id/">Beranda</a><span>&gt;</span><span>Kontak</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/id/feature.html
+++ b/examples/templates/id/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/id/">Beranda</a><span>&gt;</span><span>Fitur</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">
     <div class="footer-inner">

--- a/examples/templates/id/index.html
+++ b/examples/templates/id/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Konten utama">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">
     <div class="footer-inner">

--- a/examples/templates/id/page.html
+++ b/examples/templates/id/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/id/">Beranda</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">
     <div class="footer-inner">

--- a/examples/templates/id/post.html
+++ b/examples/templates/id/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Oleh {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">

--- a/examples/templates/id/template.html
+++ b/examples/templates/id/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/id/">Beranda</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">
     <div class="footer-inner">

--- a/examples/templates/index.html
+++ b/examples/templates/index.html
@@ -6,15 +6,15 @@
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self'; " />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/v1/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -145,7 +145,7 @@ pre code{background:none;padding:0}
         <kbd>&#8984;K</kbd>
       </button>
       <div class="nav-links" id="navLinks">
-        {{navigation}}
+        {{!navigation}}
       </div>
       <div class="nav-controls">
         <div style="position:relative">
@@ -165,7 +165,7 @@ pre code{background:none;padding:0}
     </div>
   </nav>
   <div class="mobile-menu" id="mobileMenu" role="navigation" aria-label="Mobile navigation">
-    {{navigation}}
+    {{!navigation}}
     <!-- ssg:lang-switcher -->
   </div>
   <header class="hero">
@@ -180,7 +180,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Main content">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">
     <div class="footer-inner">

--- a/examples/templates/it/contact.html
+++ b/examples/templates/it/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/it/">Home</a><span>&gt;</span><span>Contatti</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/it/feature.html
+++ b/examples/templates/it/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/it/">Home</a><span>&gt;</span><span>Funzionalità</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Piè di pagina">
     <div class="footer-inner">

--- a/examples/templates/it/index.html
+++ b/examples/templates/it/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Contenuto principale">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Piè di pagina">
     <div class="footer-inner">

--- a/examples/templates/it/page.html
+++ b/examples/templates/it/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/it/">Home</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Piè di pagina">
     <div class="footer-inner">

--- a/examples/templates/it/post.html
+++ b/examples/templates/it/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Di {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Piè di pagina">

--- a/examples/templates/it/template.html
+++ b/examples/templates/it/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/it/">Home</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Piè di pagina">
     <div class="footer-inner">

--- a/examples/templates/ja/contact.html
+++ b/examples/templates/ja/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ja/">ホーム</a><span>&gt;</span><span>お問い合わせ</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/ja/feature.html
+++ b/examples/templates/ja/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ja/">ホーム</a><span>&gt;</span><span>機能</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="フッター">
     <div class="footer-inner">

--- a/examples/templates/ja/index.html
+++ b/examples/templates/ja/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="メインコンテンツ">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="フッター">
     <div class="footer-inner">

--- a/examples/templates/ja/page.html
+++ b/examples/templates/ja/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ja/">ホーム</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="フッター">
     <div class="footer-inner">

--- a/examples/templates/ja/post.html
+++ b/examples/templates/ja/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>投稿者: {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="フッター">

--- a/examples/templates/ja/template.html
+++ b/examples/templates/ja/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ja/">ホーム</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="フッター">
     <div class="footer-inner">

--- a/examples/templates/ko/contact.html
+++ b/examples/templates/ko/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ko/">홈</a><span>&gt;</span><span>문의하기</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/ko/feature.html
+++ b/examples/templates/ko/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ko/">홈</a><span>&gt;</span><span>기능</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="푸터">
     <div class="footer-inner">

--- a/examples/templates/ko/index.html
+++ b/examples/templates/ko/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="주 콘텐츠">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="푸터">
     <div class="footer-inner">

--- a/examples/templates/ko/page.html
+++ b/examples/templates/ko/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ko/">홈</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="푸터">
     <div class="footer-inner">

--- a/examples/templates/ko/post.html
+++ b/examples/templates/ko/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>작성자: {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="푸터">

--- a/examples/templates/ko/template.html
+++ b/examples/templates/ko/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ko/">홈</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="푸터">
     <div class="footer-inner">

--- a/examples/templates/nl/contact.html
+++ b/examples/templates/nl/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/nl/">Startpagina</a><span>&gt;</span><span>Contact</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/nl/feature.html
+++ b/examples/templates/nl/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/nl/">Startpagina</a><span>&gt;</span><span>Functies</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Voettekst">
     <div class="footer-inner">

--- a/examples/templates/nl/index.html
+++ b/examples/templates/nl/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Hoofdinhoud">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Voettekst">
     <div class="footer-inner">

--- a/examples/templates/nl/page.html
+++ b/examples/templates/nl/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/nl/">Startpagina</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Voettekst">
     <div class="footer-inner">

--- a/examples/templates/nl/post.html
+++ b/examples/templates/nl/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Door {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Voettekst">

--- a/examples/templates/nl/template.html
+++ b/examples/templates/nl/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/nl/">Startpagina</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Voettekst">
     <div class="footer-inner">

--- a/examples/templates/page.html
+++ b/examples/templates/page.html
@@ -6,15 +6,15 @@
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/v1/favicon.ico" />
@@ -142,7 +142,7 @@ pre code{background:none;padding:0}
         <kbd>&#8984;K</kbd>
       </button>
       <div class="nav-links" id="navLinks">
-        {{navigation}}
+        {{!navigation}}
       </div>
       <div class="nav-controls">
         <div style="position:relative">
@@ -162,14 +162,14 @@ pre code{background:none;padding:0}
     </div>
   </nav>
   <div class="mobile-menu" id="mobileMenu" role="navigation" aria-label="Mobile navigation">
-    {{navigation}}
+    {{!navigation}}
     <!-- ssg:lang-switcher -->
   </div>
   <main id="main" class="content-wrap" aria-label="Main content">
     <div class="breadcrumb">
       <a href="/">Home</a><span>&gt;</span><span>{{title}}</span>
     </div>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">
     <div class="footer-inner">

--- a/examples/templates/pl/contact.html
+++ b/examples/templates/pl/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/pl/">Strona g&lstrok;&oacute;wna</a><span>&gt;</span><span>Kontakt</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/pl/feature.html
+++ b/examples/templates/pl/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/pl/">Strona g&lstrok;&oacute;wna</a><span>&gt;</span><span>Funkcje</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Stopka">
     <div class="footer-inner">

--- a/examples/templates/pl/index.html
+++ b/examples/templates/pl/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Tre&sacute;&cacute; g&lstrok;&oacute;wna">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Stopka">
     <div class="footer-inner">

--- a/examples/templates/pl/page.html
+++ b/examples/templates/pl/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/pl/">Strona g&lstrok;&oacute;wna</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Stopka">
     <div class="footer-inner">

--- a/examples/templates/pl/post.html
+++ b/examples/templates/pl/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Autor: {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Stopka">

--- a/examples/templates/pl/template.html
+++ b/examples/templates/pl/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/pl/">Strona g&lstrok;&oacute;wna</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Stopka">
     <div class="footer-inner">

--- a/examples/templates/post.html
+++ b/examples/templates/post.html
@@ -6,15 +6,15 @@
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/v1/favicon.ico" />
@@ -142,7 +142,7 @@ pre code{background:none;padding:0}
         <kbd>&#8984;K</kbd>
       </button>
       <div class="nav-links" id="navLinks">
-        {{navigation}}
+        {{!navigation}}
       </div>
       <div class="nav-controls">
         <div style="position:relative">
@@ -162,7 +162,7 @@ pre code{background:none;padding:0}
     </div>
   </nav>
   <div class="mobile-menu" id="mobileMenu" role="navigation" aria-label="Mobile navigation">
-    {{navigation}}
+    {{!navigation}}
     <!-- ssg:lang-switcher -->
   </div>
   <main id="main" class="content-wrap" aria-label="Main content">
@@ -174,7 +174,7 @@ pre code{background:none;padding:0}
         <span>By {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">

--- a/examples/templates/pt/contact.html
+++ b/examples/templates/pt/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/pt/">In&iacute;cio</a><span>&gt;</span><span>Contacto</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/pt/feature.html
+++ b/examples/templates/pt/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/pt/">In&iacute;cio</a><span>&gt;</span><span>Funcionalidades</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Rodap&eacute;">
     <div class="footer-inner">

--- a/examples/templates/pt/index.html
+++ b/examples/templates/pt/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Conte&uacute;do principal">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Rodap&eacute;">
     <div class="footer-inner">

--- a/examples/templates/pt/page.html
+++ b/examples/templates/pt/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/pt/">In&iacute;cio</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Rodap&eacute;">
     <div class="footer-inner">

--- a/examples/templates/pt/post.html
+++ b/examples/templates/pt/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Por {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Rodap&eacute;">

--- a/examples/templates/pt/template.html
+++ b/examples/templates/pt/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/pt/">In&iacute;cio</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Rodap&eacute;">
     <div class="footer-inner">

--- a/examples/templates/ro/contact.html
+++ b/examples/templates/ro/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ro/">Acasă</a><span>&gt;</span><span>Contact</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/ro/feature.html
+++ b/examples/templates/ro/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ro/">Acasă</a><span>&gt;</span><span>Funcționalități</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Subsol">
     <div class="footer-inner">

--- a/examples/templates/ro/index.html
+++ b/examples/templates/ro/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Conținut principal">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Subsol">
     <div class="footer-inner">

--- a/examples/templates/ro/page.html
+++ b/examples/templates/ro/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ro/">Acasă</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Subsol">
     <div class="footer-inner">

--- a/examples/templates/ro/post.html
+++ b/examples/templates/ro/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>De {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Subsol">

--- a/examples/templates/ro/template.html
+++ b/examples/templates/ro/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ro/">Acasă</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Subsol">
     <div class="footer-inner">

--- a/examples/templates/ru/contact.html
+++ b/examples/templates/ru/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ru/">Главная</a><span>&gt;</span><span>Контакты</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/ru/feature.html
+++ b/examples/templates/ru/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ru/">Главная</a><span>&gt;</span><span>Возможности</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Подвал">
     <div class="footer-inner">

--- a/examples/templates/ru/index.html
+++ b/examples/templates/ru/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Основное содержимое">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Подвал">
     <div class="footer-inner">

--- a/examples/templates/ru/page.html
+++ b/examples/templates/ru/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ru/">Главная</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Подвал">
     <div class="footer-inner">

--- a/examples/templates/ru/post.html
+++ b/examples/templates/ru/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Автор: {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Подвал">

--- a/examples/templates/ru/template.html
+++ b/examples/templates/ru/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/ru/">Главная</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Подвал">
     <div class="footer-inner">

--- a/examples/templates/sv/contact.html
+++ b/examples/templates/sv/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/sv/">Startsida</a><span>&gt;</span><span>Kontakta oss</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/sv/feature.html
+++ b/examples/templates/sv/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/sv/">Startsida</a><span>&gt;</span><span>Funktioner</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Sidfot">
     <div class="footer-inner">

--- a/examples/templates/sv/index.html
+++ b/examples/templates/sv/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Huvudinneh&aring;ll">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Sidfot">
     <div class="footer-inner">

--- a/examples/templates/sv/page.html
+++ b/examples/templates/sv/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/sv/">Startsida</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Sidfot">
     <div class="footer-inner">

--- a/examples/templates/sv/post.html
+++ b/examples/templates/sv/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Av {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Sidfot">

--- a/examples/templates/sv/template.html
+++ b/examples/templates/sv/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/sv/">Startsida</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Sidfot">
     <div class="footer-inner">

--- a/examples/templates/template.html
+++ b/examples/templates/template.html
@@ -6,15 +6,15 @@
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:*; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/v1/favicon.ico" />
@@ -142,7 +142,7 @@ pre code{background:none;padding:0}
         <kbd>&#8984;K</kbd>
       </button>
       <div class="nav-links" id="navLinks">
-        {{navigation}}
+        {{!navigation}}
       </div>
       <div class="nav-controls">
         <div style="position:relative">
@@ -162,14 +162,14 @@ pre code{background:none;padding:0}
     </div>
   </nav>
   <div class="mobile-menu" id="mobileMenu" role="navigation" aria-label="Mobile navigation">
-    {{navigation}}
+    {{!navigation}}
     <!-- ssg:lang-switcher -->
   </div>
   <main id="main" class="content-wrap" aria-label="Main content">
     <div class="breadcrumb">
       <a href="/">Home</a><span>&gt;</span><span>{{title}}</span>
     </div>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Footer">
     <div class="footer-inner">

--- a/examples/templates/th/contact.html
+++ b/examples/templates/th/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/th/">หน้าแรก</a><span>&gt;</span><span>ติดต่อ</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/th/feature.html
+++ b/examples/templates/th/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/th/">หน้าแรก</a><span>&gt;</span><span>คุณสมบัติ</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="ส่วนท้าย">
     <div class="footer-inner">

--- a/examples/templates/th/index.html
+++ b/examples/templates/th/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="เนื้อหาหลัก">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="ส่วนท้าย">
     <div class="footer-inner">

--- a/examples/templates/th/page.html
+++ b/examples/templates/th/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/th/">หน้าแรก</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="ส่วนท้าย">
     <div class="footer-inner">

--- a/examples/templates/th/post.html
+++ b/examples/templates/th/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>โดย {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="ส่วนท้าย">

--- a/examples/templates/th/template.html
+++ b/examples/templates/th/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/th/">หน้าแรก</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="ส่วนท้าย">
     <div class="footer-inner">

--- a/examples/templates/tl/contact.html
+++ b/examples/templates/tl/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/tl/">Tahanan</a><span>&gt;</span><span>Kontak</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/tl/feature.html
+++ b/examples/templates/tl/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/tl/">Tahanan</a><span>&gt;</span><span>Mga Tampok</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Talampakan">
     <div class="footer-inner">

--- a/examples/templates/tl/index.html
+++ b/examples/templates/tl/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Pangunahing nilalaman">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Talampakan">
     <div class="footer-inner">

--- a/examples/templates/tl/page.html
+++ b/examples/templates/tl/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/tl/">Tahanan</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Talampakan">
     <div class="footer-inner">

--- a/examples/templates/tl/post.html
+++ b/examples/templates/tl/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Ni {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Talampakan">

--- a/examples/templates/tl/template.html
+++ b/examples/templates/tl/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/tl/">Tahanan</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Talampakan">
     <div class="footer-inner">

--- a/examples/templates/tr/contact.html
+++ b/examples/templates/tr/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/tr/">Ana Sayfa</a><span>&gt;</span><span>İletişim</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/tr/feature.html
+++ b/examples/templates/tr/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/tr/">Ana Sayfa</a><span>&gt;</span><span>Özellikler</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Altbilgi">
     <div class="footer-inner">

--- a/examples/templates/tr/index.html
+++ b/examples/templates/tr/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Ana içerik">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Altbilgi">
     <div class="footer-inner">

--- a/examples/templates/tr/page.html
+++ b/examples/templates/tr/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/tr/">Ana Sayfa</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Altbilgi">
     <div class="footer-inner">

--- a/examples/templates/tr/post.html
+++ b/examples/templates/tr/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Yazan: {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Altbilgi">

--- a/examples/templates/tr/template.html
+++ b/examples/templates/tr/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/tr/">Ana Sayfa</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Altbilgi">
     <div class="footer-inner">

--- a/examples/templates/uk/contact.html
+++ b/examples/templates/uk/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/uk/">Головна</a><span>&gt;</span><span>Контакти</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/uk/feature.html
+++ b/examples/templates/uk/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/uk/">Головна</a><span>&gt;</span><span>Можливості</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Нижній колонтитул">
     <div class="footer-inner">

--- a/examples/templates/uk/index.html
+++ b/examples/templates/uk/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Основний вміст">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Нижній колонтитул">
     <div class="footer-inner">

--- a/examples/templates/uk/page.html
+++ b/examples/templates/uk/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/uk/">Головна</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Нижній колонтитул">
     <div class="footer-inner">

--- a/examples/templates/uk/post.html
+++ b/examples/templates/uk/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Автор: {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Нижній колонтитул">

--- a/examples/templates/uk/template.html
+++ b/examples/templates/uk/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/uk/">Головна</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Нижній колонтитул">
     <div class="footer-inner">

--- a/examples/templates/vi/contact.html
+++ b/examples/templates/vi/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/vi/">Trang chủ</a><span>&gt;</span><span>Liên hệ</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/vi/feature.html
+++ b/examples/templates/vi/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/vi/">Trang chủ</a><span>&gt;</span><span>Tính năng</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Chân trang">
     <div class="footer-inner">

--- a/examples/templates/vi/index.html
+++ b/examples/templates/vi/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Nội dung chính">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Chân trang">
     <div class="footer-inner">

--- a/examples/templates/vi/page.html
+++ b/examples/templates/vi/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/vi/">Trang chủ</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Chân trang">
     <div class="footer-inner">

--- a/examples/templates/vi/post.html
+++ b/examples/templates/vi/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Bởi {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Chân trang">

--- a/examples/templates/vi/template.html
+++ b/examples/templates/vi/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/vi/">Trang chủ</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Chân trang">
     <div class="footer-inner">

--- a/examples/templates/yo/contact.html
+++ b/examples/templates/yo/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/yo/">Ojú ewé àkọ́kọ́</a><span>&gt;</span><span>Ẹ Bá Wa Sọ̀rọ̀</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/yo/feature.html
+++ b/examples/templates/yo/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/yo/">Ojú ewé àkọ́kọ́</a><span>&gt;</span><span>Àwọn Ẹ̀yà</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Ẹsẹ̀ ojú ewé">
     <div class="footer-inner">

--- a/examples/templates/yo/index.html
+++ b/examples/templates/yo/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="Ohun àkọ́kọ́">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Ẹsẹ̀ ojú ewé">
     <div class="footer-inner">

--- a/examples/templates/yo/page.html
+++ b/examples/templates/yo/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/yo/">Ojú ewé àkọ́kọ́</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Ẹsẹ̀ ojú ewé">
     <div class="footer-inner">

--- a/examples/templates/yo/post.html
+++ b/examples/templates/yo/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>Nípasẹ̀ {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="Ẹsẹ̀ ojú ewé">

--- a/examples/templates/yo/template.html
+++ b/examples/templates/yo/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/yo/">Ojú ewé àkọ́kọ́</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="Ẹsẹ̀ ojú ewé">
     <div class="footer-inner">

--- a/examples/templates/zh-tw/contact.html
+++ b/examples/templates/zh-tw/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/zh-tw/">首頁</a><span>&gt;</span><span>聯絡我們</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/zh-tw/feature.html
+++ b/examples/templates/zh-tw/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/zh-tw/">首頁</a><span>&gt;</span><span>功能特色</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="頁尾">
     <div class="footer-inner">

--- a/examples/templates/zh-tw/index.html
+++ b/examples/templates/zh-tw/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="主要內容">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="頁尾">
     <div class="footer-inner">

--- a/examples/templates/zh-tw/page.html
+++ b/examples/templates/zh-tw/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/zh-tw/">首頁</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="頁尾">
     <div class="footer-inner">

--- a/examples/templates/zh-tw/post.html
+++ b/examples/templates/zh-tw/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>作者 {{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="頁尾">

--- a/examples/templates/zh-tw/template.html
+++ b/examples/templates/zh-tw/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/zh-tw/">首頁</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="頁尾">
     <div class="footer-inner">

--- a/examples/templates/zh/contact.html
+++ b/examples/templates/zh/contact.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/zh/">首页</a><span>&gt;</span><span>联系我们</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
     <div class="form-card">
       <form action="{{form-id}}" method="POST">
         <div class="form-group">

--- a/examples/templates/zh/feature.html
+++ b/examples/templates/zh/feature.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/zh/">首页</a><span>&gt;</span><span>功能</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="页脚">
     <div class="footer-inner">

--- a/examples/templates/zh/index.html
+++ b/examples/templates/zh/index.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -105,7 +105,7 @@ pre code{background:none;padding:0}
 .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:var(--vp-br);outline:2px solid var(--vp-br);outline-offset:1px}
 .form-group textarea{resize:vertical;min-height:120px}
 :focus-visible{outline:2px solid var(--vp-br);outline-offset:2px}
-/* Style the {{navigation}} output (Bootstrap classes from staticdatagen) */
+/* Style the {{!navigation}} output (Bootstrap classes from staticdatagen) */
 .navbar-nav{display:flex;align-items:center;gap:0;list-style:none;margin:0;padding:0}
 .nav-item{display:inline-flex}
 .nav-item a{display:block;padding:4px 12px;color:var(--vp-t1);font-size:14px;font-weight:500;text-decoration:none;text-transform:none}
@@ -238,7 +238,7 @@ pre code{background:none;padding:0}
     </div>
   </header>
   <main id="main" class="content-wrap" aria-label="主要内容">
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="页脚">
     <div class="footer-inner">

--- a/examples/templates/zh/page.html
+++ b/examples/templates/zh/page.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/zh/">首页</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="页脚">
     <div class="footer-inner">

--- a/examples/templates/zh/post.html
+++ b/examples/templates/zh/post.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -234,7 +234,7 @@ pre code{background:none;padding:0}
         <span>作者:{{author}}</span> &middot;
         <time datetime="{{item_pub_date}}">{{item_pub_date}}</time>
       </div>
-      {{content}}
+      {{!content}}
     </article>
   </main>
   <footer class="footer" id="footer" aria-label="页脚">

--- a/examples/templates/zh/template.html
+++ b/examples/templates/zh/template.html
@@ -4,16 +4,16 @@
   <meta charset="{{charset}}" />
   <link rel="preconnect" href="https://cloudcdn.pro" crossorigin />
   <title>{{title}}</title>
-  {{primary}}
-  {{opengraph}}
+  {{!primary}}
+  {{!opengraph}}
   <meta name="accessibility" content="ARIA" />
   <meta name="accessibility" content="fullKeyboardControl" />
   <meta name="accessibility" content="noFlashingHazard" />
-  {{apple}}
+  {{!apple}}
   <meta name="mobile-web-app-capable" content="yes" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; media-src 'self';" />
-  {{microsoft}}
-  {{twitter}}
+  {{!microsoft}}
+  {{!twitter}}
   <link rel="alternate" href="{{url}}" hreflang="{{hreflang}}" />
   <link rel="canonical" href="{{url}}" />
   <link rel="icon" type="image/x-icon" href="{{cdn}}/{{short_name}}/images/favicon.ico" />
@@ -229,7 +229,7 @@ pre code{background:none;padding:0}
       <a href="/zh/">首页</a><span>&gt;</span><span>{{title}}</span>
     </div>
     <h1 class="page-title">{{title}}</h1>
-    <div class="content">{{content}}</div>
+    <div class="content">{{!content}}</div>
   </main>
   <footer class="footer" id="footer" aria-label="页脚">
     <div class="footer-inner">

--- a/src/plugins/postprocess/html_fix.rs
+++ b/src/plugins/postprocess/html_fix.rs
@@ -212,6 +212,12 @@ fn find_modern_mobile_web_app_capable(html: &str) -> Option<usize> {
 /// after the legacy Apple variant so installed-PWA support works in Chrome
 /// without console deprecation warnings. Handles minified HTML where the
 /// `name=` attribute may be unquoted and may appear after `content=`.
+///
+/// When the legacy meta is HTML-escaped (e.g. `&lt;meta
+/// name=&quot;apple-mobile-web-app-capable&quot;…&gt;` leaked into body
+/// content via a misconfigured template), no usable anchor exists. In that
+/// case, fall back to injecting the modern meta into `<head>` so the
+/// modern-companion validator still passes.
 pub(super) fn inject_mobile_web_app_capable_meta(html: &str) -> String {
     let modern = "<meta name=\"mobile-web-app-capable\" content=\"yes\">";
     // Find the apple-variant attribute name. Tolerate quoted/unquoted forms.
@@ -221,16 +227,41 @@ pub(super) fn inject_mobile_web_app_capable_meta(html: &str) -> String {
         "name=apple-mobile-web-app-capable",
     ];
     let name_pos = candidates.iter().find_map(|n| html.find(n));
-    let Some(name_pos) = name_pos else {
-        return html.to_string();
-    };
-    // Walk forward to the next `>` that closes this <meta> tag.
-    let after = &html[name_pos..];
-    let Some(rel_close) = after.find('>') else {
-        return html.to_string();
-    };
-    let insert_at = name_pos + rel_close + 1;
-    format!("{}{modern}{}", &html[..insert_at], &html[insert_at..])
+    if let Some(name_pos) = name_pos {
+        // Walk forward to the next `>` that closes this <meta> tag.
+        let after = &html[name_pos..];
+        if let Some(rel_close) = after.find('>') {
+            let insert_at = name_pos + rel_close + 1;
+            return format!(
+                "{}{modern}{}",
+                &html[..insert_at],
+                &html[insert_at..]
+            );
+        }
+    }
+    // Fallback: the legacy meta is present only in escaped form (no real
+    // anchor in the source). Inject the modern meta into <head> so Chrome
+    // gets the companion and the modern-companion validator passes.
+    inject_modern_meta_into_head(html, modern)
+}
+
+/// Injects a `<meta>` tag just before `</head>`, or just after `<head>` if
+/// the close tag isn't present. If neither anchor exists, prepends the meta
+/// so the document still contains the marker — but in practice every
+/// well-formed page has a `<head>` element.
+fn inject_modern_meta_into_head(html: &str, meta: &str) -> String {
+    // Prefer inserting right before </head> so it lives in the head block
+    // regardless of where the apple-meta string appeared.
+    let lower = html.to_ascii_lowercase();
+    if let Some(pos) = lower.find("</head>") {
+        return format!("{}{meta}{}", &html[..pos], &html[pos..]);
+    }
+    if let Some(pos) = lower.find("<head>") {
+        let insert_at = pos + "<head>".len();
+        return format!("{}{meta}{}", &html[..insert_at], &html[insert_at..]);
+    }
+    // No <head> at all — prepend so the substring is at least present.
+    format!("{meta}{html}")
 }
 
 /// Fix JSON-LD date fields from RFC 2822 to ISO 8601.
@@ -722,17 +753,49 @@ mod tests {
 
     #[test]
     fn test_inject_mobile_web_app_capable_meta_edge_cases() {
-        // Missing apple meta
-        assert_eq!(
-            inject_mobile_web_app_capable_meta("<head></head>"),
-            "<head></head>"
+        // Missing apple meta — no <head> either, must inject to keep
+        // substring present (caller only invokes this when the legacy
+        // substring is present somewhere in the document).
+        let no_head = inject_mobile_web_app_capable_meta("plain text");
+        assert!(
+            no_head.contains("name=\"mobile-web-app-capable\""),
+            "fallback should inject modern meta: {no_head}"
         );
-        // Unclosed tag
-        assert_eq!(
-            inject_mobile_web_app_capable_meta(
-                "<meta name=\"apple-mobile-web-app-capable\""
-            ),
-            "<meta name=\"apple-mobile-web-app-capable\""
+
+        // Unclosed apple meta tag — no closing `>` so the primary anchor
+        // path cannot insert; falls through to head-injection. Since
+        // there's also no <head>, the meta is prepended.
+        let unclosed = inject_mobile_web_app_capable_meta(
+            "<meta name=\"apple-mobile-web-app-capable\"",
+        );
+        assert!(
+            unclosed.contains("name=\"mobile-web-app-capable\""),
+            "fallback should inject modern meta: {unclosed}"
+        );
+    }
+
+    #[test]
+    fn test_inject_modern_meta_fallback_when_apple_meta_is_escaped() {
+        // Regression for PR #511 / feat/v0.0.41: staticdatagen-rendered
+        // pages can leak the legacy apple meta as fully HTML-escaped body
+        // text (`&lt;meta name=&quot;apple-…&quot;…&gt;`). The injector
+        // cannot find a `name="apple-…"` anchor, so it must fall back to
+        // injecting the modern companion into <head> instead.
+        let html = "<html><head><title>x</title></head><body>\
+                    &lt;meta name=&quot;apple-mobile-web-app-capable&quot; \
+                    content=&quot;yes&quot;&gt;</body></html>";
+        let result = apply_html_fixes(html);
+        assert!(
+            result.contains("name=\"mobile-web-app-capable\""),
+            "modern companion must be injected even when legacy is escaped"
+        );
+        // And it should land inside <head>, not after the escaped body text.
+        let modern_pos =
+            result.find("name=\"mobile-web-app-capable\"").unwrap();
+        let head_close_pos = result.find("</head>").unwrap();
+        assert!(
+            modern_pos < head_close_pos,
+            "modern meta should live inside <head>:\n{result}"
         );
     }
 


### PR DESCRIPTION
## Summary

Drops `serde_yml` and `libyml` from the dependency graph entirely by bumping `frontmatter-gen 0.0.5 → 0.0.6` and `staticdatagen 0.0.8 → 0.0.9`, both of which now consume `noyalib` (pure-Rust, `#![forbid(unsafe_code)]`) in place of the unmaintained C-FFI YAML chain.

Resolves Dependabot security alerts:
- **#19** libyml HIGH (RUSTSEC-2025-0067)
- **#20** serde_yml MEDIUM (unsoundness)

`Cargo.lock` is **net −1177 lines**: dropping the libyml/serde_yml chain also removes a long tail of transitive crates (vrd, tower, tokio-rustls, yaml-rust2 0.9, sha2 0.10, etc.).

### Absorbed Dependabot PRs

**cargo:**
- #498 `http-handle` 0.0.4 → 0.0.5
- #499 `sha2` 0.10.9 → 0.11.0
- #510 minor-and-patch group (openssl, uuid)

**github-actions:**
- #502 `docker/setup-buildx-action` 4.0.0 → 4.1.0
- #503 `docker/login-action` 4.1.0 → 4.2.0
- #504 `docker/build-push-action` 7.1.0 → 7.2.0
- #509 `codecov/codecov-action` v4 → v7

### Upstream releases that enabled this

- `frontmatter-gen 0.0.6` — noyalib migration
- `metadata-gen 0.0.4` — noyalib migration
- `html-generator 0.0.6` — noyalib migration
- `rss-gen 0.0.5` — `dtt 0.0.10` API fix
- `sitemap-gen 0.0.2` — CI consolidation + dep bumps
- `staticdatagen 0.0.9` — cascade of the above

## Test plan

- [ ] CI green on push (cargo check/test/clippy/fmt across the matrix)
- [ ] Codecov coverage holds at ≥98% regions/lines/functions floor
- [ ] Audit shows zero open RUSTSEC advisories for libyml/serde_yml/yaml-rust2
- [ ] SBOM regen reflects the dep-graph slim-down
- [ ] Workspace `cargo test --workspace --lib --bins` still passes (verified locally: 1778 + 14 = 1792 tests, 0 failed)