### PR TITLE
fix(docs): resolve 5 broken intra-doc links blocking the Document workflow

### DIFF
--- a/crates/ssg-rpc-macro/src/lib.rs
+++ b/crates/ssg-rpc-macro/src/lib.rs
@@ -8,8 +8,10 @@
 //! 1. Re-emits the original function untouched, so direct callers in
 //!    Rust keep working.
 //! 2. Generates a sibling `__SSG_RPC_<fn_name>` static of type
-//!    [`ssg_rpc::RpcDescriptor`] which carries the function name plus
-//!    a type-erased dispatcher trampoline.
+//!    `ssg_rpc::RpcDescriptor` which carries the function name plus
+//!    a type-erased dispatcher trampoline. (Plain code reference
+//!    rather than an intra-doc link — proc-macro crates can't
+//!    resolve symbols in their sibling runtime crate at doc time.)
 //! 3. Wires the static into the inventory-based dispatch registry so
 //!    `ssg_rpc::dispatch(name, json)` resolves it at runtime.
 //!

--- a/crates/ssg-search/src/lib.rs
+++ b/crates/ssg-search/src/lib.rs
@@ -9,7 +9,7 @@
 //! Provides everything needed to ship a privacy-first, fully static
 //! semantic search experience for an SSG site:
 //!
-//! - A **build-side** API ([`build`]) that walks document text, runs the
+//! - A **build-side** API ([`Artifacts::from_docs`]) that walks document text, runs the
 //!   embedder, L2-normalises every vector, and serialises the corpus
 //!   into a flat little-endian `f32` blob (`embeddings.bin`) together
 //!   with a `manifest.json`, `model.bin`, and `tokenizer.bin`.

--- a/src/core/pipeline.rs
+++ b/src/core/pipeline.rs
@@ -356,7 +356,8 @@ pub fn build_pipeline(
     (plugins, ctx, build_dir, site_dir)
 }
 
-/// Appends ISR-specific plugins (currently just [`IsrManifestPlugin`]).
+/// Appends ISR-specific plugins (currently just
+/// [`crate::isr_manifest::IsrManifestPlugin`]).
 ///
 /// Pulled out of [`register_default_plugins`] so the default plugin
 /// graph stays byte-identical when `--isr` is not passed (AC9 of

--- a/src/plugins/image_plugin.rs
+++ b/src/plugins/image_plugin.rs
@@ -70,8 +70,8 @@ const AVIF_SPEED: u8 = 4;
 pub struct ImageOptimizationPlugin {
     /// WebP encoding quality (1–100). Defaults to 80.
     pub quality: u8,
-    /// AVIF encoding quality (1–100). Defaults to 70 — see
-    /// [`DEFAULT_AVIF_QUALITY`] for the rationale.
+    /// AVIF encoding quality (1–100). Defaults to 70 — see the
+    /// `DEFAULT_AVIF_QUALITY` private constant for the rationale.
     pub avif_quality: u8,
     /// Skip AVIF encoding for non-priority images (saves build time
     /// at the cost of bandwidth on modern browsers). Hero images
@@ -332,8 +332,8 @@ fn process_image(
 /// disk.
 ///
 /// `quality` is clamped to `1..=100`; the speed preset is fixed at
-/// [`AVIF_SPEED`] (4 — "balanced"). Alpha channels use the same quality
-/// as colour.
+/// `AVIF_SPEED` (4 — "balanced", private constant). Alpha channels
+/// use the same quality as colour.
 ///
 /// # Examples
 ///
@@ -350,7 +350,7 @@ fn process_image(
 /// ```
 ///
 /// # Errors
-/// Returns [`SsgError::Other`] wrapping the underlying `ravif::Error`
+/// Returns [`SsgError::Io`] wrapping the underlying `ravif::Error`
 /// if rav1e fails to encode (effectively a bug in ravif/rav1e — the
 /// inputs we feed are always valid).
 #[cfg(feature = "image-optimization")]

--- a/src/plugins/search_index.rs
+++ b/src/plugins/search_index.rs
@@ -24,7 +24,7 @@
 //! to the browser separately and lazily — never inlined into HTML —
 //! and the worker fetches it the first time the user types. The
 //! existing `SearchPlugin` is on every page; this plugin is opt-in
-//! via [`PluginManager::register`].
+//! via [`crate::plugin::PluginManager::register`].
 
 use crate::error::{PathErrorExt, SsgError};
 use crate::plugin::{Plugin, PluginContext};


### PR DESCRIPTION
## Summary

The Document workflow on \`main\` has been failing since v0.0.44 landed because several doc-comments referenced symbols out of scope or pointed at private items. CI uses \`-D rustdoc::broken-intra-doc-links\` so the workflow exits non-zero.

This PR fixes the 7 surfaced links:

| File | Was | Now |
|---|---|---|
| \`crates/ssg-search/src/lib.rs:12\` | \`[\`build\`]\` | \`[\`Artifacts::from_docs\`]\` |
| \`crates/ssg-rpc-macro/src/lib.rs:11\` | \`[\`ssg_rpc::RpcDescriptor\`]\` | plain code span (proc-macro crates can't resolve runtime-crate symbols at doc time) |
| \`src/core/pipeline.rs:359\` | \`[\`IsrManifestPlugin\`]\` | \`[\`crate::isr_manifest::IsrManifestPlugin\`]\` |
| \`src/plugins/image_plugin.rs:74\` | \`[\`DEFAULT_AVIF_QUALITY\`]\` (private const) | plain code span |
| \`src/plugins/image_plugin.rs:335\` | \`[\`AVIF_SPEED\`]\` (private const) | plain code span |
| \`src/plugins/image_plugin.rs:353\` | \`[\`SsgError::Other\`]\` (non-existent variant) | \`[\`SsgError::Io\`]\` (the real return type) |
| \`src/plugins/search_index.rs:27\` | \`[\`PluginManager::register\`]\` | \`[\`crate::plugin::PluginManager::register\`]\` |

## Verify locally

\`\`\`bash
RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" \\
  cargo doc --workspace --no-deps --all-features
\`\`\`

Exits 0 with this PR; exits 101 on \`main\`.

## Why now

Spotted while preparing the v0.0.44 tag-publish. The release pipeline depends on docs.rs / GitHub Pages being publishable, so this must merge before the tag is pushed.