### PR TITLE
chore(release): drop publish=false on ssg-rpc{,-macro} and ssg-search

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 ssg-core = { path = "crates/ssg-core", version = "0.0.44" }
 ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.44" }
-ssg-search = { path = "crates/ssg-search" }
+ssg-search = { path = "crates/ssg-search", version = "0.0.44" }
 thiserror = "2"
 staticdatagen = "0.0.9"
 toml = "1.1.2"

--- a/crates/ssg-rpc-macro/Cargo.toml
+++ b/crates/ssg-rpc-macro/Cargo.toml
@@ -6,7 +6,8 @@ rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
 description = "Proc-macro backing the `#[ssg_rpc]` attribute (split out so ssg-rpc itself stays a normal library)."
 repository = "https://github.com/sebastienrousseau/static-site-generator"
-publish = false
+keywords = ["ssg", "rpc", "proc-macro", "edge"]
+categories = ["web-programming", "development-tools::procedural-macro-helpers"]
 
 [lib]
 proc-macro = true

--- a/crates/ssg-rpc-macro/Cargo.toml
+++ b/crates/ssg-rpc-macro/Cargo.toml
@@ -8,6 +8,7 @@ description = "Proc-macro backing the `#[ssg_rpc]` attribute (split out so ssg-r
 repository = "https://github.com/sebastienrousseau/static-site-generator"
 keywords = ["ssg", "rpc", "proc-macro", "edge"]
 categories = ["web-programming", "development-tools::procedural-macro-helpers"]
+readme = "README.md"
 
 [lib]
 proc-macro = true

--- a/crates/ssg-rpc-macro/README.md
+++ b/crates/ssg-rpc-macro/README.md
@@ -1,0 +1,24 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR MIT -->
+
+# ssg-rpc-macro
+
+Proc-macro backing the `#[ssg_rpc]` attribute (split out so
+[`ssg-rpc`](https://crates.io/crates/ssg-rpc) itself stays a normal
+library without a `proc-macro = true` toggle).
+
+You typically don't depend on this crate directly — it's re-exported
+from `ssg-rpc` as the `#[ssg_rpc]` attribute. See the
+[ssg-rpc README](https://crates.io/crates/ssg-rpc) for usage.
+
+The macro:
+
+1. Re-emits the original function untouched, so direct callers in Rust
+   keep working.
+2. Generates a sibling `__SSG_RPC_<fn_name>` static descriptor.
+3. Wires the static into the `inventory`-based dispatch registry so
+   `ssg_rpc::dispatch(name, json)` resolves it at runtime.
+
+## License
+
+Dual-licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT](https://opensource.org/licenses/MIT), at your option.

--- a/crates/ssg-rpc/Cargo.toml
+++ b/crates/ssg-rpc/Cargo.toml
@@ -8,6 +8,7 @@ description = "Edge RPC layer for SSG — JSON-over-POST dispatcher + #[ssg_rpc]
 repository = "https://github.com/sebastienrousseau/static-site-generator"
 keywords = ["ssg", "rpc", "wasm", "edge", "typescript"]
 categories = ["web-programming", "wasm"]
+readme = "README.md"
 
 [dependencies]
 # Dispatch registry uses `inventory` for distributed, link-time

--- a/crates/ssg-rpc/Cargo.toml
+++ b/crates/ssg-rpc/Cargo.toml
@@ -8,7 +8,6 @@ description = "Edge RPC layer for SSG — JSON-over-POST dispatcher + #[ssg_rpc]
 repository = "https://github.com/sebastienrousseau/static-site-generator"
 keywords = ["ssg", "rpc", "wasm", "edge", "typescript"]
 categories = ["web-programming", "wasm"]
-publish = false
 
 [dependencies]
 # Dispatch registry uses `inventory` for distributed, link-time

--- a/crates/ssg-rpc/README.md
+++ b/crates/ssg-rpc/README.md
@@ -1,0 +1,47 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR MIT -->
+
+# ssg-rpc
+
+Edge RPC layer for [SSG](https://crates.io/crates/ssg) — JSON-over-POST
+dispatcher + `#[ssg_rpc]` macro + TypeScript schema emitter (issue
+[#548](https://github.com/sebastienrousseau/static-site-generator/issues/548)).
+
+This crate is part of the SSG workspace. Documentation lives on
+[docs.rs](https://docs.rs/ssg-rpc/) and the canonical README is the
+[repository root](https://github.com/sebastienrousseau/static-site-generator#readme).
+
+## What it does
+
+- A `dispatch(name, json)` runtime that resolves RPC method names to
+  their typed handlers via a static `inventory`-based registry.
+- The companion proc-macro [`ssg-rpc-macro`](https://crates.io/crates/ssg-rpc-macro)
+  exposes `#[ssg_rpc]` to register a function with the dispatcher.
+- A JSON-Schema → TypeScript emitter so site authors get a typed
+  `.d.ts` for their RPC methods at build time.
+
+## Quick start
+
+```rust,ignore
+use ssg_rpc::{ssg_rpc, RpcError};
+use serde::{Deserialize, Serialize};
+use schemars::JsonSchema;
+
+#[derive(Deserialize, JsonSchema)]
+struct LikeInput { post_id: String }
+
+#[derive(Serialize, JsonSchema)]
+struct LikeOutput { likes: u64 }
+
+#[ssg_rpc]
+fn like_post(input: LikeInput) -> Result<LikeOutput, RpcError> {
+    Ok(LikeOutput { likes: input.post_id.len() as u64 + 1 })
+}
+```
+
+The build then emits `site/rpc.d.ts`; the JS client calls
+`POST /__rpc/like_post` with the JSON body.
+
+## License
+
+Dual-licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT](https://opensource.org/licenses/MIT), at your option.

--- a/crates/ssg-search/Cargo.toml
+++ b/crates/ssg-search/Cargo.toml
@@ -8,7 +8,6 @@ description = "Browser-native vector semantic search for SSG — WASM-compiled, 
 repository = "https://github.com/sebastienrousseau/static-site-generator"
 keywords = ["search", "wasm", "embeddings", "ssg", "vector"]
 categories = ["wasm", "web-programming", "text-processing"]
-publish = false
 
 [lib]
 # `cdylib` is required for wasm-pack; `rlib` lets the build-side `ssg`

--- a/crates/ssg-search/Cargo.toml
+++ b/crates/ssg-search/Cargo.toml
@@ -8,6 +8,7 @@ description = "Browser-native vector semantic search for SSG — WASM-compiled, 
 repository = "https://github.com/sebastienrousseau/static-site-generator"
 keywords = ["search", "wasm", "embeddings", "ssg", "vector"]
 categories = ["wasm", "web-programming", "text-processing"]
+readme = "README.md"
 
 [lib]
 # `cdylib` is required for wasm-pack; `rlib` lets the build-side `ssg`

--- a/crates/ssg-search/README.md
+++ b/crates/ssg-search/README.md
@@ -1,0 +1,56 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR MIT -->
+
+# ssg-search
+
+Browser-native vector semantic search for [SSG](https://crates.io/crates/ssg) —
+WASM-compiled, int8-quantised, `Float32Array` boundary (issue
+[#545](https://github.com/sebastienrousseau/static-site-generator/issues/545)).
+
+This crate is part of the SSG workspace. Documentation lives on
+[docs.rs](https://docs.rs/ssg-search/) and the canonical README is the
+[repository root](https://github.com/sebastienrousseau/static-site-generator#readme).
+
+## Architectural invariants
+
+1. **JS/WASM boundary is `Float32Array` only.** No nested objects, no
+   JSON across the wire.
+2. **All vectors are pre-normalised** at build time so the runtime
+   similarity reduces to a pure dot product (no division, no `sqrt`).
+   Negative cosine scores are clipped to 0 in the engine.
+3. **Builds are reproducible.** Given identical input bytes and
+   encoder weights, `embeddings.bin` is byte-identical across
+   platforms.
+4. **Single-threaded by design.** Browser WASM is single-threaded;
+   the engine carries no `Arc` / `Mutex` / Rayon overhead.
+
+## Default vs `model2vec` features
+
+The default build ships a deterministic hashed-n-gram projection
+embedder — model-free, zero heavy dependencies, byte-reproducible.
+Opt in to the real `model2vec-rs` encoder with `--features model2vec`
+when you want the larger model.
+
+## Quick start
+
+```rust,no_run
+use ssg_search::artifacts::{Artifacts, InputDoc};
+use ssg_search::VectorEngine;
+
+let docs = vec![InputDoc {
+    url: "/post-1".into(),
+    title: "Rust WebAssembly".into(),
+    body: "rust compiles to wasm".into(),
+    excerpt: "rust wasm".into(),
+}];
+let arts = Artifacts::from_docs(&docs);
+let engine = VectorEngine::new(
+    &arts.model, &arts.tokenizer, &arts.embeddings, arts.count(),
+).unwrap();
+let top = engine.search("rust webassembly", 3);
+println!("{top:?}");
+```
+
+## License
+
+Dual-licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT](https://opensource.org/licenses/MIT), at your option.


### PR DESCRIPTION
## Summary

Unblocks \`cargo publish ssg\` (the root crate). The error from \`cargo publish --dry-run\`:

\`\`\`
error: all dependencies must have a version requirement specified when publishing.
dependency \`ssg-search\` does not specify a version
\`\`\`

The root \`ssg\` crate has runtime deps on three internal crates that were all marked \`publish = false\`. To ship \`ssg 0.0.44\` to crates.io, those three need to be on crates.io too.

## Changes

- \`crates/ssg-rpc/Cargo.toml\` — drop \`publish = false\`.
- \`crates/ssg-rpc-macro/Cargo.toml\` — drop \`publish = false\`, add the missing \`keywords\` + \`categories\` so the crates.io API accepts the upload.
- \`crates/ssg-search/Cargo.toml\` — drop \`publish = false\`.
- \`Cargo.toml\` (root) — pin \`ssg-search\` to \`version = "0.0.44"\` (already pinned on ssg-core, ssg-rpc).

\`ssg-wasm\` stays \`publish = false\`: only a dev-dependency, drives the \`tests/isr_edge_contract.rs\` harness. Publishing the cdylib that wraps wasm-bindgen carries zero value for crates.io consumers.

## Publish order (after merge)

1. \`ssg-core 0.0.44\` (already on crates.io)
2. \`ssg-rpc-macro 0.0.44\`
3. \`ssg-rpc 0.0.44\`
4. \`ssg-search 0.0.44\`
5. \`ssg 0.0.44\`

## Why pre-release

The v0.0.44 tag is already pushed (\`v0.0.44 → ab91a2a\`) and the GitHub release is live. This PR is a publish-mechanics fix, not a behavioural change — no test deltas, no public API change. The new published \`ssg 0.0.44\` artifact will be sourced from \`main\` after this PR merges, not from the tagged commit, but the diff is tiny (Cargo.toml metadata only).