### PR TITLE
fix(docs): unbreak 📚 Document workflow on main

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -29,8 +29,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Generate documentation
+        # `--cfg docsrs` is intentionally NOT set here. That flag would
+        # activate `#![cfg_attr(docsrs, feature(doc_cfg))]` in
+        # `crates/ssg-search/src/lib.rs`, which requires the nightly
+        # toolchain — the local pages build uses stable. The real
+        # docs.rs render reads `[package.metadata.docs.rs]` in
+        # `Cargo.toml` (where the flag IS set, with multi-target
+        # nightly). Has been failing this workflow since v0.0.44
+        # (commit 6036b46) until this fix.
         run: |
-          RUSTDOCFLAGS="--cfg docsrs" cargo doc --no-deps --all-features --workspace
+          cargo doc --no-deps --all-features --workspace
           echo '<html><head><meta http-equiv="refresh" content="0; url=/ssg/"></head><body></body></html>' > ./target/doc/index.html
 
       - name: Upload Pages artifact

--- a/src/core/content_stager.rs
+++ b/src/core/content_stager.rs
@@ -37,7 +37,7 @@
 //! 2. **Multi-line quoted-scalar collapse.** `staticdatagen 0.0.10`
 //!    pins `metadata-gen = "0.0.4"` (the pre-#20 release; tracked at
 //!    [staticdatagen #100](https://github.com/sebastienrousseau/staticdatagen/issues/100)).
-//!    [`copy_tree`] applies the same collapse pass that's now upstream
+//!    `copy_tree` (the per-file staging helper) applies the same collapse pass that's now upstream
 //!    in `metadata-gen 0.0.5`, so the user's content sees consistent
 //!    behaviour regardless of which `metadata-gen` is transitively
 //!    resolved.


### PR DESCRIPTION
## Summary

Two coordinated fixes that re-green the **📚 Document** workflow, which has been failing on every push to main since v0.0.44 (commit 6036b46).

| | |
|---|---|
| 1 | `.github/workflows/document.yml` — drop `RUSTDOCFLAGS=\"--cfg docsrs\"` |
| 2 | `src/core/content_stager.rs` — fix `[\`copy_tree\`]` private-intra-doc link introduced in v0.0.46 |

## Why

### Fix 1 — workflow flag drop
The flag activates `#![cfg_attr(docsrs, feature(doc_cfg))]` in `crates/ssg-search/src/lib.rs`, which requires the **nightly** toolchain. The local pages build uses **stable**, so the combination triggers:

```
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> crates/ssg-search/src/lib.rs:5:21
  |
5 | #![cfg_attr(docsrs, feature(doc_cfg))]
  |                     ^^^^^^^^^^^^^^^^
```

This has been failing every Document run for the past 10 pushes (back to commit `6036b46` on 2026-06-26).

The real **docs.rs** render is independent — it reads `[package.metadata.docs.rs]` in `Cargo.toml` (where `--cfg docsrs` IS set, on a nightly multi-target build). What crates.io users see at <https://docs.rs/ssg/0.0.46> is unaffected by this change.

### Fix 2 — broken intra-doc link
The v0.0.46 module-docstring rewrite in `src/core/content_stager.rs` linked `` [`copy_tree`] `` from `//!` commentary, but `copy_tree` is a private helper. With `-D rustdoc::private-intra-doc-links` set workspace-wide, this errors:

```
error: public documentation for `content_stager` links to private item `copy_tree`
```

Switched to a plain `` `copy_tree` `` code span — no link, no warning.

## Test plan

- [x] `cargo doc --no-deps --all-features --workspace` exits 0 (verified locally on c14f4f9)
- [ ] Full Document workflow on PR