### PR TITLE
security: patch ammonia mXSS (RUSTSEC-2026-0193), document quick-xml DoS ignores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,14 +86,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
 dependencies = [
- "cssparser 0.35.0",
- "html5ever 0.35.0",
+ "cssparser 0.37.0",
+ "html5ever 0.39.0",
  "maplit",
- "tendril 0.4.3",
  "url",
 ]
 
@@ -1004,19 +1003,6 @@ name = "cssparser"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
-dependencies = [
- "cssparser-macros 0.6.1",
- "dtoa-short",
- "itoa",
- "phf 0.11.3",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
 dependencies = [
  "cssparser-macros 0.6.1",
  "dtoa-short",
@@ -1962,18 +1948,7 @@ dependencies = [
  "log",
  "mac",
  "markup5ever 0.14.1",
- "match_token 0.1.0",
-]
-
-[[package]]
-name = "html5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
-dependencies = [
- "log",
- "markup5ever 0.35.0",
- "match_token 0.35.0",
+ "match_token",
 ]
 
 [[package]]
@@ -2555,24 +2530,13 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
-dependencies = [
- "log",
- "tendril 0.4.3",
- "web_atoms 0.1.3",
-]
-
-[[package]]
-name = "markup5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril 0.5.0",
- "web_atoms 0.2.5",
+ "web_atoms",
 ]
 
 [[package]]
@@ -2580,17 +2544,6 @@ name = "match_token"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5981,18 +5934,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "web_atoms"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
-dependencies = [
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -58,5 +58,12 @@ ignore = [
     "RUSTSEC-2025-0057", # fxhash (unmaintained) — via selectors/scraper
     "RUSTSEC-2025-0119", # number_prefix (unmaintained) — via indicatif
     "RUSTSEC-2025-0141", # bincode (unmaintained) — via syntect
-    "RUSTSEC-2026-0097", # rand 0.8.5 (unsound w/ custom logger) — via phf_generator, no 0.8.6 fix yet
+    # quick-xml <0.41: parser DoS pair (quadratic dup-attr check; unbounded
+    # ns-decl allocation). Both paths are transitive and build-time only —
+    # ssg parses no untrusted XML at runtime. 0.39.4 arrives via
+    # sitemap-gen→html-generator 0.0.3→mdx-gen 0.0.1→comrak 0.28→syntect→
+    # plist; another copy via staticdatagen→metadata-gen 0.0.4. Drop once
+    # a staticdatagen/metadata-gen release bumps quick-xml to >=0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -57,7 +57,7 @@ version = "0.4.0"
 criteria = "safe-to-run"
 
 [[exemptions.ammonia]]
-version = "4.1.2"
+version = "4.1.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.anstream]]


### PR DESCRIPTION
## Summary

`cargo-deny` started failing on `main` once RUSTSEC-2026-0193/0194/0195 were published — this now blocks every open PR, including the entire pending dependabot batch (#603, #605).

- **RUSTSEC-2026-0193** (ammonia mXSS via MathML `annotation-xml` encoding strip): patched by updating `ammonia` to the latest 4.1.x — no code changes needed, semver-compatible fix release.
- **RUSTSEC-2026-0194 / RUSTSEC-2026-0195** (quick-xml <0.41: quadratic duplicate-attribute check; unbounded namespace-declaration allocation): both transitive and build-time only — ssg parses no untrusted XML at runtime. Documented as tracked ignores in `deny.toml`, same pattern as the existing unmaintained-crate ignores, with an explicit removal condition (staticdatagen/metadata-gen bumping quick-xml to `>=0.41`).

Also dropped the `RUSTSEC-2026-0097` (rand 0.8.5 unsound-logger) ignore: a prior transitive dependency update already cleared it from the graph, so `cargo-deny` was reporting the ignore itself as unmatched dead weight.

## Verification

`cargo deny check advisories bans licenses` green; `cargo check` clean.

## Priority

Small and low-risk — recommend merging first so it unblocks CI on the other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)