### PR TITLE
chore(deps): replace serde_yaml_ng with noyalib for direct YAML parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,6 +3013,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "noyalib"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "903f06e76b14b388b47d651b9498b008888a9475084087e51c294731acbf16c1"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "memchr",
+ "rustc-hash 2.1.2",
+ "ryu",
+ "serde",
+ "serde_ignored",
+ "smallvec",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4662,6 +4678,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4690,19 +4716,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_yaml_ng"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4933,6 +4946,7 @@ dependencies = [
  "minify-html 0.15.0",
  "minijinja",
  "notify",
+ "noyalib 0.0.12",
  "oxc_allocator",
  "oxc_codegen",
  "oxc_minifier",
@@ -4946,7 +4960,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml_ng",
  "serial_test",
  "sha2",
  "ssg-core",
@@ -4972,10 +4985,10 @@ name = "ssg-core"
 version = "0.0.46"
 dependencies = [
  "log",
+ "noyalib 0.0.12",
  "pulldown-cmark",
  "serde",
  "serde_json",
- "serde_yaml_ng",
  "sha2",
  "tempfile",
  "toml 1.1.2+spec-1.1.0",
@@ -5722,12 +5735,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,11 +263,12 @@ frontmatter-gen = "0.0.6"
 # Pure-Rust YAML parser for data/*.{yml,yaml} files loaded into
 # template globals (issue #536). The previous implementation parsed
 # YAML through `serde_json`, which silently dropped any non-JSON
-# YAML — indented lists, flow lists, nested maps. `serde_yaml_ng` is
-# the maintained fork of the unmaintained `serde_yaml`, has no C
-# deps, and is the same crate the workspace pulls in transitively
-# via `noyalib` / `frontmatter-gen`.
-serde_yaml_ng = "0.10"
+# YAML — indented lists, flow lists, nested maps. `noyalib` is a
+# from-scratch YAML implementation (same author, same crate used by
+# `ssg-core`'s frontmatter parser) — zero unsafe, no C deps, and
+# deliberately carries no dependency on the unmaintained `serde_yaml`
+# lineage `serde_yaml_ng` forked from.
+noyalib = "0.0.12"
 
 # Optional observability stack (issue #422). Both crates are
 # `optional = true` — they enter the build only when the `otel`

--- a/crates/ssg-core/Cargo.toml
+++ b/crates/ssg-core/Cargo.toml
@@ -19,9 +19,11 @@ serde_json = "1"
 # hand-rolled split-on-colon parser stored every value as a string
 # and silently dropped lists, flow lists, and nested maps —
 # `tags:\n  - welcome` became the literal string "" under the key
-# "tags". `serde_yaml_ng` is the maintained fork of `serde_yaml`,
-# pure Rust, no C deps, and clean on `wasm32-unknown-unknown`.
-serde_yaml_ng = "0.10"
+# "tags". `noyalib` is a from-scratch YAML implementation (not a
+# `serde_yaml` fork) — zero unsafe, no C deps, deliberately no
+# dependency on the unmaintained `serde_yaml` lineage, clean on
+# `wasm32-unknown-unknown`.
+noyalib = "0.0.12"
 sha2 = { version = "0.11", default-features = false }
 toml = "1"
 

--- a/crates/ssg-core/src/lib.rs
+++ b/crates/ssg-core/src/lib.rs
@@ -149,7 +149,7 @@ pub fn parse_frontmatter(
         if let Some(end) = after.find("---") {
             let fm_str = &after[..end];
             let body = &after[end + 3..];
-            match serde_yaml_ng::from_str::<serde_json::Value>(fm_str) {
+            match noyalib::from_str::<serde_json::Value>(fm_str) {
                 Ok(serde_json::Value::Object(map)) => {
                     return (map.into_iter().collect(), body.to_string());
                 }

--- a/src/core/template_engine.rs
+++ b/src/core/template_engine.rs
@@ -280,8 +280,7 @@ impl TemplateEngine {
                     }
                 },
                 "yml" | "yaml" => {
-                    match serde_yaml_ng::from_str::<serde_json::Value>(&content)
-                    {
+                    match noyalib::from_str::<serde_json::Value>(&content) {
                         Ok(v) => Some(v),
                         Err(e) => {
                             log::warn!(

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,4 +1,8 @@
 
 # cargo-vet audits file
 
-[audits]
+[[audits.noyalib]]
+who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.0.12"
+notes = 'Same-author crate, reviewed from the published crates.io source. #![forbid(unsafe_code)] enforced at lib.rs:342 — all grep hits for the string "unsafe" are doc comments describing this guarantee, not code. build.rs runs only `rustc --version` (via the RUSTC env var) to detect a nightly toolchain for an optional SIMD feature gate; no network access, no arbitrary command execution. No unsafe FFI, no ambient file/network I/O outside the documented YAML parse/serialize surface.'

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1548,6 +1548,10 @@ criteria = "safe-to-deploy"
 version = "0.29.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.serde_ignored]]
+version = "0.1.14"
+criteria = "safe-to-deploy"
+
 [[exemptions.serde_json]]
 version = "1.0.150"
 criteria = "safe-to-deploy"
@@ -1558,10 +1562,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.serde_spanned]]
 version = "1.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_yaml_ng]]
-version = "0.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.serial_test]]


### PR DESCRIPTION
## Summary

`ssg` (root) and `ssg-core` each had one direct `serde_yaml_ng::from_str` call site (data/*.{yml,yaml} template globals, issue #536; frontmatter parsing, issue #537). Both now use `noyalib::from_str` instead — the same author's own from-scratch YAML implementation, not a `serde_yaml` fork.

## Why

`noyalib` deliberately carries no dependency on the unmaintained `serde_yaml` lineage `serde_yaml_ng` forked from — its own `Cargo.toml` documents this explicitly, specifically to keep it out of downstream `cargo-audit`/`cargo-deny` results. Swapping our two direct call sites means `serde_yaml_ng` drops out of the dependency tree entirely (confirmed via `cargo tree -i serde_yaml_ng` — no longer resolves to any package).

## Note on existing transitive noyalib versions

`html-generator`, `frontmatter-gen`, and `metadata-gen` (same-author upstream crates) already transitively depend on `noyalib` at older versions (`0.0.3`, `0.0.8`) for their own internal use, independent of this change — those `cargo-vet` exemptions are untouched. This PR adds `noyalib 0.0.12` as ssg's own **direct** dependency and includes a first-party `cargo-vet` audit for it (same-author crate, `#![forbid(unsafe_code)]` verified at the source, `build.rs` reviewed — it only runs `rustc --version` for nightly-feature detection, no network/exec).

## Verification

- `noyalib::from_str::<serde_json::Value>` confirmed a drop-in match for the removed `serde_yaml_ng` call signature via a standalone scratch test before touching the real call sites.
- Full workspace suite: 2,503 tests green.
- `ssg-core` compiles clean for `wasm32-unknown-unknown` (release profile) — confirms noyalib's wasm-cleanliness claim.
- `cargo clippy --lib --all-features -- -D warnings` clean.
- `cargo vet --locked` and `cargo deny check bans licenses` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)