### PR TITLE
fix(release): add ssg-a11y to the crates.io publish loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -587,14 +587,18 @@ jobs:
 
       - name: Publish workspace sub-crates to crates.io (dep order)
         # `cargo publish -p ssg` fails if ssg-core / ssg-rpc-macro /
-        # ssg-rpc / ssg-search at the matching version don't already
-        # exist on crates.io (path deps are verified against the
-        # registry). Publish them first, in dependency order:
+        # ssg-rpc / ssg-search / ssg-a11y at the matching version don't
+        # already exist on crates.io (path deps are verified against
+        # the registry). Publish them first, in dependency order:
         #
         #   ssg-core         (no internal deps)
         #   ssg-rpc-macro    (no internal deps)
         #   ssg-rpc          (depends on ssg-rpc-macro)
         #   ssg-search       (no internal deps)
+        #   ssg-a11y         (no internal deps)
+        #
+        # ssg-wasm is deliberately excluded: it carries `publish = false`
+        # in its own Cargo.toml and is not a dependency of `ssg`.
         #
         # crates.io's index needs ~30s after each publish before the
         # next crate can depend on the freshly-published version, so
@@ -609,7 +613,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           set -euo pipefail
-          for c in ssg-core ssg-rpc-macro ssg-rpc ssg-search; do
+          for c in ssg-core ssg-rpc-macro ssg-rpc ssg-search ssg-a11y; do
             echo "::group::cargo publish -p $c"
             if cargo publish -p "$c" --locked --no-verify; then
               echo "✓ $c published"


### PR DESCRIPTION
## Summary

v0.0.47's release run failed at the final `cargo publish -p ssg` step: `ssg` now depends on `ssg-a11y` (added during this release's work), but the sub-crate publish loop was never updated to include it, and `ssg-a11y` had never been published to crates.io at all.

- `ssg-core`, `ssg-rpc-macro`, `ssg-rpc`, and `ssg-search` all published successfully before this failure.
- The GitHub Release (all 5 platform binaries, checksums, SLSA provenance) also completed successfully, since it runs before the crates.io publish step.
- `ssg-a11y` has no internal workspace dependencies, so it publishes cleanly at any position in the loop.
- `ssg-wasm` is deliberately **not** added: it carries `publish = false` in its own `Cargo.toml` and isn't a dependency of `ssg`.

This fixes the workflow for future releases. Completing v0.0.47's own missing `ssg-a11y` + `ssg` crates.io publish still needs a manual `cargo publish` step with registry credentials — tracked separately, not part of this PR.

## Test plan
- [x] Confirmed `ssg-a11y` returns 404 on crates.io (never published)
- [x] Confirmed `ssg-wasm` has `publish = false` and is not an `ssg` dependency
- [x] Confirmed `ssg` depends on `ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.47" }`
- [ ] Verify on the next tagged release that the full sub-crate loop (including `ssg-a11y`) publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)