### PR TITLE
security: harden CI supply-chain posture (pins, permissions, SAST, RUSTSEC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
@@ -52,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: No stray *.profraw outside target/
@@ -89,13 +92,13 @@ jobs:
     # cache and got timeout-cancelled. 15m matches the test job.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: lint
 
@@ -155,11 +158,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: test-${{ matrix.os }}
 
@@ -191,12 +194,15 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write # upload-sarif (ssg's own audit SARIF, #562)
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: examples
       - name: Build all examples
@@ -245,7 +251,7 @@ jobs:
           fi
       - name: Upload SARIF to GitHub Code Scanning (#562)
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: ssg-audit.sarif
           category: ssg-audit
@@ -257,13 +263,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: coverage
       - name: Install cargo-llvm-cov
@@ -313,7 +319,7 @@ jobs:
           [ "$ok" = "1" ]
       - name: Upload to Codecov
         if: always()
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.lcov
           fail_ci_if_error: false
@@ -327,11 +333,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: audit
       - name: Install cargo-deny
@@ -350,11 +356,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: vet
       - name: Install cargo-vet
@@ -396,11 +402,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: semver-checks
       - name: Install cargo-semver-checks

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# CodeQL static analysis (SAST). Rust support reached general
+# availability in CodeQL CLI 2.23.3 with build-mode "none" -- no
+# compilation step is required, so this workflow just checks out the
+# source and hands it to the extractor directly.
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, independent of push/PR activity.
+    - cron: "20 3 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze (rust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+      packages: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        with:
+          languages: rust
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        with:
+          category: "/language:rust"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -30,6 +30,9 @@ concurrency:
   group: miri-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
@@ -57,16 +60,16 @@ jobs:
     # the `.miri-skip` allowlist stabilises and Miri is reliably green.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install nightly + miri component
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@efcb852328a9f50117170cc43094fb6f09eaf1ae # nightly
         with:
           components: miri, rust-src
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: miri
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
-  packages: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -462,6 +459,10 @@ jobs:
     # the GitHub Release or crates.io publish on it.
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write # gh release create/edit + upload assets
+      id-token: write # attest-build-provenance
+      attestations: write # attest-build-provenance
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -188,7 +188,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
-      - run: npm install -g pa11y
+      - run: npm install -g pa11y@9.1.1
 
       - name: Build SSG
         run: cargo build --locked

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -13,12 +13,14 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   visual:
     name: Screenshot diff (3 viewports)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # pushes updated baselines when update_baselines=true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -9,6 +9,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   wasm-build:
     name: Build & test ssg-core (wasm32)
@@ -21,7 +24,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: cargo install wasm-pack --locked
 
       - name: Build ssg-core for wasm32
         run: cargo build -p ssg-core --target wasm32-unknown-unknown
@@ -33,7 +36,7 @@ jobs:
         run: wasm-pack build crates/ssg-wasm --target web --out-dir ../../pkg
 
       - name: Install Chrome for headless tests
-        uses: browser-actions/setup-chrome@latest
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
         with:
           chrome-version: stable
 
@@ -99,7 +102,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: cargo install wasm-pack --locked
 
       - name: Build ssg-search for wasm32 (default features)
         run: cargo build -p ssg-search --target wasm32-unknown-unknown --release
@@ -118,7 +121,7 @@ jobs:
         run: wasm-pack build crates/ssg-search --target web --release -- --features wasm
 
       - name: Install Chrome for headless tests
-        uses: browser-actions/setup-chrome@latest
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
         with:
           chrome-version: stable
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Built and pushed by .github/workflows/release.yml on every `v*` tag.
 
 # ── Stage 1: build ─────────────────────────────────────────────────
-FROM rust:1.88-slim AS builder
+FROM rust:1.88-slim@sha256:38bc5a86d998772d4aec2348656ed21438d20fcdce2795b56ca434cf21430d89 AS builder
 
 WORKDIR /usr/src/ssg
 
@@ -22,7 +22,7 @@ COPY . .
 RUN cargo build --release --locked --bin ssg
 
 # ── Stage 2: runtime ───────────────────────────────────────────────
-FROM debian:bookworm-slim AS runtime
+FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df AS runtime
 
 LABEL org.opencontainers.image.title="static-site-generator"
 LABEL org.opencontainers.image.description="A Content-First Open Source Static Site Generator (SSG) crafted in Rust"

--- a/deny.toml
+++ b/deny.toml
@@ -68,4 +68,5 @@ ignore = [
     # a metadata-gen release with quick-xml ≥0.41 clears the 0.40 path.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+    "RUSTSEC-2026-0173", # proc-macro-error2 (unmaintained) — via defmt-macros/defmt, an optional jiff feature
 ]

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Ignore list for the OSV-Scanner-based checks OpenSSF Scorecard runs
+# (`.github/workflows/scorecard.yml`, "Vulnerabilities" check). Mirrors
+# `deny.toml`'s `[advisories].ignore` list exactly -- both files must be
+# updated together when a RUSTSEC advisory is added, resolved, or the
+# underlying dependency is upgraded past the affected range.
+#
+# All entries below are "unmaintained crate" informational advisories
+# (or, for the two quick-xml entries, documented low-risk build-time-only
+# findings) in transitive dependencies that cannot be resolved without
+# upstream releases. See `deny.toml` for the per-crate reasoning.
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0320" # yaml-rust (unmaintained) — via syntect/comrak
+reason = "unmaintained transitive dep, no upstream fix available"
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0436" # paste (unmaintained) — via dtt
+reason = "unmaintained transitive dep, no upstream fix available"
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0057" # fxhash (unmaintained) — via selectors/scraper
+reason = "unmaintained transitive dep, no upstream fix available"
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0119" # number_prefix (unmaintained) — via indicatif
+reason = "unmaintained transitive dep, no upstream fix available"
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0141" # bincode (unmaintained) — via syntect
+reason = "unmaintained transitive dep, no upstream fix available"
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0194"
+reason = "quick-xml <0.41 parser DoS pair, transitive + build-time only; ssg parses no untrusted XML at runtime. See deny.toml for the removal plan."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0195"
+reason = "quick-xml <0.41 parser DoS pair, transitive + build-time only; ssg parses no untrusted XML at runtime. See deny.toml for the removal plan."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0173" # proc-macro-error2 (unmaintained) — via defmt-macros/defmt, an optional jiff feature
+reason = "unmaintained transitive dep, no upstream fix available"


### PR DESCRIPTION
## Summary

Addresses the bulk of the open GitHub code-scanning alerts (OpenSSF Scorecard), all fixable via code:

- **Pin every GitHub Action** in `ci.yml`, `miri.yml`, and `wasm.yml` to a full commit SHA, reusing SHAs already vetted elsewhere in this repo where the same action+version is used, resolving fresh ones (dereferencing annotated tags to their commit) where needed.
- **Pin Docker base images** in `Dockerfile` to their manifest-list digests — verified directly against the registry API, not just trusted from the alert text.
- **Pin `npm install -g pa11y`** to its current version instead of installing whatever's latest at run time.
- **Replace the wasm-pack `curl | sh` installer** with `cargo install wasm-pack --locked`, going through crates.io's checksummed registry instead of an unverified download-then-run pattern.
- **Add least-privilege `permissions:` blocks** to `ci.yml`/`miri.yml`/`wasm.yml` (none declared previously). Rescope `release.yml`/`visual.yml` from a blanket top-level `write` grant down to `contents: read` by default, with job-level overrides only where write access is actually needed.
- **Add a CodeQL Rust analysis workflow** (`codeql.yml`) — Rust reached GA in CodeQL CLI 2.23.3 with build-mode "none". The existing `codeql-action` usage in `ci.yml` only uploads ssg's own custom audit SARIF, which Scorecard doesn't recognize as a general-purpose SAST tool.
- **Add `osv-scanner.toml`** mirroring `deny.toml`'s RUSTSEC ignore list (Scorecard's vulnerability check reads this file, not `deny.toml`), including one advisory (`RUSTSEC-2026-0173`, `proc-macro-error2` unmaintained) that `deny.toml` didn't have yet.
- **Dismissed** (not fixed, on the code-scanning UI) one alert: `release.yml`'s SLSA reusable-workflow reference must stay tag-pinned per `slsa-github-generator`'s own documented requirement — SHA-pinning it would break SLSA v1.1 Level 3 attestation.
- **Dismissed** two site-content alerts confirmed by-design after investigation: `csp_sri.CSP-DRIFT` (different pages legitimately have different hash-strict CSP strings) and `links.LINK-EXTERNAL-SKIPPED` (CI intentionally skips real network calls for external link checks).

Not addressed here (need explicit maintainer decision / external process, not a code fix): `BranchProtectionID`/`CodeReviewID` (main has no branch protection — a GitHub repo setting) and `CIIBestPracticesID` (requires registering with bestpractices.dev). The remaining `metadata.OG-IMAGE` alerts (11, on tag pages) are being fixed in a separate PR.

## Test plan
- [x] `cargo build --all-features`
- [x] `cargo clippy --all-features -- -D warnings` (clean)
- [x] `cargo vet --locked` (Vetting Succeeded)
- [x] `cargo deny check` (clean)
- [x] `actionlint` on every touched workflow (clean except one pre-existing, unrelated shellcheck nit in miri.yml)
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on every touched workflow file
- [x] Docker manifest-list digests verified directly against the registry API

🤖 Generated with [Claude Code](https://claude.com/claude-code)