### PR TITLE
chore(release): v0.0.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.48] - 2026-07-25
 
 ### Planned / Upcoming (deferred — not v0.0.46 scope)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,15 +35,6 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
@@ -86,12 +77,12 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
  "cssparser 0.37.0",
- "html5ever 0.39.0",
+ "html5ever",
  "maplit",
  "url",
 ]
@@ -154,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -228,7 +219,7 @@ dependencies = [
  "num-traits",
  "pastey 0.1.1",
  "rayon",
- "thiserror 2.0.18",
+ "thiserror",
  "v_frame",
  "y4m",
 ]
@@ -297,28 +288,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-matrix"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1216dde2607f9479a3ea619c9e1c73449c28cfe787a40fcd6033ac7520f8f26"
-dependencies = [
- "bit-vec 0.8.0",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
 
 [[package]]
 name = "bit-vec"
@@ -455,12 +431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,97 +479,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cfg"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8327e1fda66185d40ec4169b861ee3c79fc78162d25514f90d8b589ba300ba"
-dependencies = [
- "bit-matrix",
- "bit-vec 0.7.0",
- "cfg-classify",
- "cfg-earley",
- "cfg-generate",
- "cfg-grammar",
- "cfg-predict",
- "cfg-sequence",
- "cfg-symbol",
-]
-
-[[package]]
-name = "cfg-classify"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e3687abb27fd23d794e9b058ca7f12c807d0e362469f428e62e1043439cba9"
-dependencies = [
- "bit-matrix",
- "bit-vec 0.7.0",
- "cfg-grammar",
- "cfg-symbol",
-]
-
-[[package]]
-name = "cfg-earley"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b4c4941ea6fe5edb52e7aaa922af3b05d6d3bb9ba11b4deaa54f5c0fb67334"
-dependencies = [
- "bit-matrix",
- "cfg-classify",
- "cfg-grammar",
- "cfg-sequence",
- "cfg-symbol",
-]
-
-[[package]]
-name = "cfg-generate"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430d3dc05b50b40775e02368e07e50e83e32b9f38fdfeee73ba7b5527e291c2b"
-dependencies = [
- "cfg-symbol",
-]
-
-[[package]]
-name = "cfg-grammar"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973a96188797a40399157b6f89f536dea6690304fa15b032655cb3e39411237f"
-dependencies = [
- "bit-vec 0.7.0",
- "cfg-symbol",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg-predict"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120a96c6c1c78d28daf234d98c6b235698d1c9ba150758b7f577c06786c4e52e"
-dependencies = [
- "cfg-grammar",
- "cfg-symbol",
-]
-
-[[package]]
-name = "cfg-sequence"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d725833a11fbece5aa6b8118cf0e69fbc024837abe8c571749f3113d017e77"
-dependencies = [
- "cfg-grammar",
- "cfg-symbol",
-]
-
-[[package]]
-name = "cfg-symbol"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a00c99b50a3584312822b053283eea0dada2bb97a0e3178707f8c25afd5cd4"
 
 [[package]]
 name = "cfg_aliases"
@@ -681,7 +564,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -722,48 +605,6 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c93ab3577cca16b4a1d80a88c2e0cd8b6e969e51696f0bbb0d1dcb0157109832"
-dependencies = [
- "caseless",
- "clap",
- "derive_builder",
- "entities",
- "memchr",
- "once_cell",
- "regex",
- "shell-words",
- "slug",
- "syntect",
- "typed-arena",
- "unicode_categories",
- "xdg 2.5.2",
-]
-
-[[package]]
-name = "comrak"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ae8f3e7e3f3d424cbb33354fc36943d507327d210aa5794b0192f4be726c6d"
-dependencies = [
- "bon",
- "caseless",
- "clap",
- "entities",
- "memchr",
- "once_cell",
- "regex",
- "shell-words",
- "slug",
- "syntect",
- "typed-arena",
- "unicode_categories",
- "xdg 2.5.2",
-]
-
-[[package]]
-name = "comrak"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321d20bf105b6871a49da44c5fbb93e90a7cd6178ea5a9fe6cbc1e6d4504bc5e"
@@ -777,13 +618,13 @@ dependencies = [
  "jetscii",
  "phf 0.13.1",
  "phf_codegen 0.13.1",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "shell-words",
  "smallvec",
  "syntect",
  "typed-arena",
  "unicode_categories",
- "xdg 3.0.0",
+ "xdg",
 ]
 
 [[package]]
@@ -802,12 +643,12 @@ dependencies = [
  "jetscii",
  "phf 0.13.1",
  "phf_codegen 0.13.1",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "shell-words",
  "smallvec",
  "syntect",
  "typed-arena",
- "xdg 3.0.0",
+ "xdg",
 ]
 
 [[package]]
@@ -821,6 +662,18 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -947,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -990,19 +843,6 @@ name = "cssparser"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be934d936a0fbed5bcdc01042b770de1398bf79d0e192f49fa7faea0e99281e"
-dependencies = [
- "cssparser-macros 0.6.1",
- "dtoa-short",
- "itoa",
- "phf 0.11.3",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
 dependencies = [
  "cssparser-macros 0.6.1",
  "dtoa-short",
@@ -1212,7 +1052,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1257,17 +1097,6 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
@@ -1286,12 +1115,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
@@ -1366,30 +1189,14 @@ dependencies = [
 
 [[package]]
 name = "dtt"
-version = "0.0.9"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d0ded54a7c92b3bbc6d8a6a5ae97f120caa634ab7ee49d0b20ac2041037e2d"
-dependencies = [
- "lazy_static",
- "paste",
- "regex",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "dtt"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300fa4cbe63b08446f74755c6cc002fb70e45bf50c32390f475d19b1ef23bc8e"
+checksum = "d3ad961df245c82bc67098f5bd69640d3194a081df8f0f5df1f017db4a05292a"
 dependencies = [
  "pastey 0.2.3",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "version_check",
 ]
@@ -1399,12 +1206,6 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "ego-tree"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "ego-tree"
@@ -1534,7 +1335,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc1cf9c4720703ea04d9eb4a191ac8e43b597805742e102fb7eaa4d9c3f5b27"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1661,7 +1462,7 @@ dependencies = [
  "serde_json",
  "simple_logger",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
@@ -1683,16 +1484,6 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
 
 [[package]]
 name = "futures-core"
@@ -1727,15 +1518,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1827,16 +1609,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.12",
- "bumpalo",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1899,62 +1671,27 @@ dependencies = [
 
 [[package]]
 name = "html-generator"
-version = "0.0.3"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996c5a71e1cf23548209a503067083647ff3e850f6fa49f5947abc66a3259de0"
-dependencies = [
- "cfg",
- "comrak 0.32.0",
- "lazy_static",
- "log",
- "mdx-gen 0.0.1",
- "minify-html 0.15.0",
- "once_cell",
- "regex",
- "scraper 0.22.0",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "uuid",
- "version_check",
-]
-
-[[package]]
-name = "html-generator"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ccffe0fe0548aef64a326edde299c50a806f77b7338281bc561f20a6ae8a2e"
+checksum = "07a2f2b47c9f8d662fbfd6f8c0c0ecbc092182110430309cb641d68bd0283018"
 dependencies = [
  "ammonia",
  "comrak 0.50.0",
  "getrandom 0.3.4",
  "indexmap",
  "log",
- "mdx-gen 0.0.2",
- "minify-html 0.18.1",
- "noyalib 0.0.3",
+ "mdx-gen",
+ "minify-html",
+ "noyalib 0.0.15",
  "once_cell",
  "pulldown-latex",
  "regex",
- "scraper 0.27.0",
+ "scraper",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "toml 1.1.2+spec-1.1.0",
  "version_check",
-]
-
-[[package]]
-name = "html5ever"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
-dependencies = [
- "log",
- "mac",
- "markup5ever 0.14.1",
- "match_token",
 ]
 
 [[package]]
@@ -1964,7 +1701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
- "markup5ever 0.39.0",
+ "markup5ever",
 ]
 
 [[package]]
@@ -1991,7 +1728,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "version_check",
 ]
 
@@ -2172,10 +1909,23 @@ version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "console",
+ "console 0.15.11",
  "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console 0.16.4",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -2230,15 +1980,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2367,7 +2108,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
  "version_check",
  "whatlang",
 ]
@@ -2489,7 +2230,7 @@ dependencies = [
  "mime",
  "precomputed-hash",
  "selectors 0.37.0",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2500,12 +2241,6 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
-
-[[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -2531,38 +2266,13 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
-dependencies = [
- "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
- "tendril 0.4.3",
-]
-
-[[package]]
-name = "markup5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
- "tendril 0.5.0",
+ "tendril",
  "web_atoms",
-]
-
-[[package]]
-name = "match_token"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -2602,28 +2312,6 @@ dependencies = [
 
 [[package]]
 name = "mdx-gen"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba95ca121d5154b8ec38928b5421207ce7354d9b924e04dc648589d09d9861c"
-dependencies = [
- "anyhow",
- "comrak 0.28.0",
- "env_logger",
- "html-escape",
- "lazy_static",
- "log",
- "regex",
- "serde",
- "serde_json",
- "syntect",
- "thiserror 1.0.69",
- "tokio",
- "toml 0.8.23",
- "version_check",
-]
-
-[[package]]
-name = "mdx-gen"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c4c8dc74c2c82e042d3aa231598122d8def5d1a09b96ae2c3e3075b342d838"
@@ -2638,7 +2326,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syntect",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "toml 0.8.23",
  "version_check",
@@ -2658,20 +2346,17 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "metadata-gen"
-version = "0.0.4"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bdfc9095ce2b6a57ef0302307e0bfc0d9127f498a48f1a687ab60ed22cf1a15"
+checksum = "7c8843b4135e8e03bf105fd877a39b1f0cc619686f6b9dc6a87d95b081bc2e4f"
 dependencies = [
- "anyhow",
- "dtt 0.0.10",
- "noyalib 0.0.8",
- "quick-xml 0.40.1",
+ "dtt",
+ "noyalib 0.0.15",
+ "quick-xml",
  "regex",
- "scraper 0.27.0",
  "serde",
  "serde_json",
- "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
@@ -2697,31 +2382,15 @@ dependencies = [
 
 [[package]]
 name = "minify-html"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd4517942a8e7425c990b14977f86a63e4996eed7b15cfcca1540126ac5ff25"
-dependencies = [
- "aho-corasick 0.7.20",
- "lazy_static",
- "lightningcss",
- "memchr",
- "minify-html-common 0.0.2",
- "minify-js",
- "once_cell",
- "rustc-hash 1.1.0",
-]
-
-[[package]]
-name = "minify-html"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644c1511457e5f70dcbc03c932d4bd26351eceb8657b119c919dde2e65b6d120"
 dependencies = [
  "ahash 0.8.12",
- "aho-corasick 1.1.4",
+ "aho-corasick",
  "lightningcss",
  "memchr",
- "minify-html-common 0.0.3",
+ "minify-html-common",
  "once_cell",
  "oxc_allocator 0.95.0",
  "oxc_codegen 0.95.0",
@@ -2732,42 +2401,17 @@ dependencies = [
 
 [[package]]
 name = "minify-html-common"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697a6b40dffdc5de10c0cbd709dc2bc2039cea9dab8aaa636eb9a49d6b411780"
-dependencies = [
- "aho-corasick 0.7.20",
- "itertools 0.12.1",
- "lazy_static",
- "memchr",
- "rustc-hash 1.1.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "minify-html-common"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c3d71ae301c4e36949937ed9d121e1bf6847f2dc69ec20929b379d14659aac"
 dependencies = [
  "ahash 0.8.12",
- "aho-corasick 1.1.4",
+ "aho-corasick",
  "itertools 0.14.0",
  "memchr",
  "once_cell",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "minify-js"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d6c512a82abddbbc13b70609cb2beff01be2c7afff534d6e5e1c85e438fc8b"
-dependencies = [
- "lazy_static",
- "parse-js",
 ]
 
 [[package]]
@@ -2965,26 +2609,13 @@ dependencies = [
 
 [[package]]
 name = "noyalib"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5dc50790bdee1e91bb3407f58b9529e0de45dc65f7ffb06b514ecdbbd579489"
-dependencies = [
- "indexmap",
- "memchr",
- "rustc-hash 2.1.2",
- "serde",
- "smallvec",
-]
-
-[[package]]
-name = "noyalib"
 version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14057395c16a4230575c6f86bfa074db87e8458626d3e56b20c2454334a7e50c"
 dependencies = [
  "indexmap",
  "memchr",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "smallvec",
 ]
@@ -2998,10 +2629,23 @@ dependencies = [
  "indexmap",
  "itoa",
  "memchr",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "ryu",
  "serde",
  "serde_ignored",
+ "smallvec",
+]
+
+[[package]]
+name = "noyalib"
+version = "0.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9014fb34654ac4f54a4ff52d5207b1e4a764604fced568c3a1d71ee99d1fc300"
+dependencies = [
+ "indexmap",
+ "memchr",
+ "rustc-hash",
+ "serde",
  "smallvec",
 ]
 
@@ -3176,10 +2820,10 @@ checksum = "abb7a1163a5501f935f8722d839b576491b749c695e7a066aa0b8df988b806df"
 dependencies = [
  "flate2",
  "postcard",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3190,9 +2834,9 @@ checksum = "373741e2febe6df186995b668f295e46fd402ee12f312ea2fda8b3b6312c0885"
 dependencies = [
  "miniz_oxide 0.9.1",
  "postcard",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3205,7 +2849,7 @@ dependencies = [
  "owo-colors",
  "oxc-miette-derive 2.7.1",
  "textwrap",
- "thiserror 2.0.18",
+ "thiserror",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -3220,7 +2864,7 @@ dependencies = [
  "owo-colors",
  "oxc-miette-derive 3.0.0",
  "textwrap",
- "thiserror 2.0.18",
+ "thiserror",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -3257,7 +2901,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.16.1",
  "oxc_data_structures 0.95.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -3269,7 +2913,7 @@ dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
  "oxc_data_structures 0.138.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -3373,7 +3017,7 @@ dependencies = [
  "oxc_sourcemap 6.1.1",
  "oxc_span 0.95.0",
  "oxc_syntax 0.95.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -3395,7 +3039,7 @@ dependencies = [
  "oxc_span 0.138.0",
  "oxc_str",
  "oxc_syntax 0.138.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -3407,7 +3051,7 @@ dependencies = [
  "cow-utils",
  "oxc-browserslist 2.3.1",
  "oxc_syntax 0.95.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
 ]
 
@@ -3420,7 +3064,7 @@ dependencies = [
  "cow-utils",
  "oxc-browserslist 3.0.9",
  "oxc_syntax 0.138.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
 ]
 
@@ -3535,7 +3179,7 @@ dependencies = [
  "oxc_semantic 0.95.0",
  "oxc_span 0.95.0",
  "oxc_syntax 0.95.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -3553,7 +3197,7 @@ dependencies = [
  "oxc_span 0.138.0",
  "oxc_str",
  "oxc_syntax 0.138.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -3578,7 +3222,7 @@ dependencies = [
  "oxc_span 0.95.0",
  "oxc_syntax 0.95.0",
  "oxc_traverse 0.95.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -3604,7 +3248,7 @@ dependencies = [
  "oxc_str",
  "oxc_syntax 0.138.0",
  "oxc_traverse 0.138.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -3626,7 +3270,7 @@ dependencies = [
  "oxc_regular_expression 0.95.0",
  "oxc_span 0.95.0",
  "oxc_syntax 0.95.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "seq-macro",
 ]
 
@@ -3650,7 +3294,7 @@ dependencies = [
  "oxc_span 0.138.0",
  "oxc_str",
  "oxc_syntax 0.138.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "seq-macro",
 ]
 
@@ -3666,7 +3310,7 @@ dependencies = [
  "oxc_diagnostics 0.95.0",
  "oxc_span 0.95.0",
  "phf 0.13.1",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "unicode-id-start",
 ]
 
@@ -3683,7 +3327,7 @@ dependencies = [
  "oxc_span 0.138.0",
  "oxc_str",
  "phf 0.14.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "unicode-id-start",
 ]
 
@@ -3704,7 +3348,7 @@ dependencies = [
  "oxc_span 0.95.0",
  "oxc_syntax 0.95.0",
  "phf 0.13.1",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "self_cell",
 ]
 
@@ -3726,7 +3370,7 @@ dependencies = [
  "oxc_span 0.138.0",
  "oxc_str",
  "oxc_syntax 0.138.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "self_cell",
  "smallvec",
 ]
@@ -3739,7 +3383,7 @@ checksum = "6d378eb8bad20e89d66276aebab51f6a5408571092cac94abdd3eabb773713d6"
 dependencies = [
  "base64-simd 0.8.0",
  "json-escape-simd",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "serde_json",
 ]
@@ -3752,7 +3396,7 @@ checksum = "73326286c78270f92c55e1a643a64daa558fc8a8e06fa0ddbe32fabb3d8eea11"
 dependencies = [
  "base64-simd 0.8.0",
  "json-escape-simd",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "serde_json",
 ]
@@ -3851,7 +3495,7 @@ dependencies = [
  "oxc_semantic 0.95.0",
  "oxc_span 0.95.0",
  "oxc_syntax 0.95.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -3870,7 +3514,7 @@ dependencies = [
  "oxc_span 0.138.0",
  "oxc_str",
  "oxc_syntax 0.138.0",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -3895,7 +3539,7 @@ dependencies = [
  "phf 0.11.3",
  "phf_codegen 0.11.3",
  "precomputed-hash",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "smallvec",
 ]
 
@@ -3934,19 +3578,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "parse-js"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec3b11d443640ec35165ee8f6f0559f1c6f41878d70330fe9187012b5935f02"
-dependencies = [
- "aho-corasick 0.7.20",
- "bumpalo",
- "hashbrown 0.13.2",
- "lazy_static",
- "memchr",
 ]
 
 [[package]]
@@ -4141,13 +3772,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap",
- "quick-xml 0.39.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -4317,7 +3948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec 0.8.0",
+ "bit-vec",
  "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
@@ -4397,18 +4028,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -4539,7 +4161,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror 2.0.18",
+ "thiserror",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -4631,7 +4253,7 @@ version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
- "aho-corasick 1.1.4",
+ "aho-corasick",
  "memchr",
  "regex-automata",
  "regex-syntax",
@@ -4643,7 +4265,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
- "aho-corasick 1.1.4",
+ "aho-corasick",
  "memchr",
  "regex-syntax",
 ]
@@ -4717,24 +4339,18 @@ dependencies = [
 
 [[package]]
 name = "rss-gen"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be5690e7b2de7129db714a796f194c861962f2ac88254c48d883c6a2ea38a0b"
+checksum = "3bca6514ce21f46a2b9e5b7faa01df744c8add5321aeef221a58d1b9f390ff2e"
 dependencies = [
  "log",
- "quick-xml 0.40.1",
+ "quick-xml",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "url",
  "version_check",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -4875,47 +4491,17 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3d051b884f40e309de6c149734eab57aa8cc1347992710dc80bcc1c2194c15"
-dependencies = [
- "cssparser 0.34.0",
- "ego-tree 0.10.0",
- "getopts",
- "html5ever 0.29.1",
- "precomputed-hash",
- "selectors 0.26.0",
- "tendril 0.4.3",
-]
-
-[[package]]
-name = "scraper"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e65d9d888567588db4c12da1087598d0f6f8b346cc2c5abc91f05fc2dffe2"
-dependencies = [
- "cssparser 0.34.0",
- "ego-tree 0.10.0",
- "getopts",
- "html5ever 0.29.1",
- "precomputed-hash",
- "selectors 0.26.0",
- "tendril 0.4.3",
-]
-
-[[package]]
-name = "scraper"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
 dependencies = [
  "cssparser 0.37.0",
- "ego-tree 0.11.0",
+ "ego-tree",
  "getopts",
- "html5ever 0.39.0",
+ "html5ever",
  "precomputed-hash",
  "selectors 0.38.0",
- "tendril 0.5.0",
+ "tendril",
 ]
 
 [[package]]
@@ -4926,38 +4512,19 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "selectors"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
-dependencies = [
- "bitflags 2.13.0",
- "cssparser 0.34.0",
- "derive_more 0.99.20",
- "fxhash",
- "log",
- "new_debug_unreachable",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "precomputed-hash",
- "servo_arc",
- "smallvec",
-]
-
-[[package]]
-name = "selectors"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cfaaa6035167f0e604e42723c7650d59ee269ef220d7bbe0565602c8a0173b9"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser 0.36.0",
- "derive_more 2.1.1",
+ "derive_more",
  "log",
  "new_debug_unreachable",
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "servo_arc",
  "smallvec",
 ]
@@ -4970,13 +4537,13 @@ checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser 0.37.0",
- "derive_more 2.1.1",
+ "derive_more",
  "log",
  "new_debug_unreachable",
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "servo_arc",
  "smallvec",
 ]
@@ -5238,27 +4805,27 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sitemap-gen"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d75dfdcabff12eb2ae2d3af23d2cfc9c0ce3d8e66da83d4e9b35b88fbb63df"
+checksum = "109a9444242ba72c636d0cf3deb178a79483aca15f692484bd1a763cc04f2945"
 dependencies = [
  "clap",
- "dtt 0.0.9",
+ "dtt",
  "env_logger",
  "euxis-commons",
- "html-generator 0.0.3",
- "indicatif",
+ "html-generator",
+ "indicatif 0.18.6",
  "lazy_static",
  "log",
  "regex",
- "scraper 0.23.1",
+ "scraper",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tokio",
  "url",
  "version_check",
- "xml-rs 0.8.28",
+ "xml-rs",
 ]
 
 [[package]]
@@ -5266,16 +4833,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "smallvec"
@@ -5316,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "ssg"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5329,7 +4886,7 @@ dependencies = [
  "lightningcss",
  "log",
  "lol_html",
- "minify-html 0.18.1",
+ "minify-html",
  "minijinja",
  "notify",
  "noyalib 0.0.12",
@@ -5355,7 +4912,7 @@ dependencies = [
  "ssg-wasm",
  "staticdatagen",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
@@ -5399,7 +4956,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssg-rpc-macro",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -5452,20 +5009,20 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "staticdatagen"
-version = "0.0.10"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65cac1c53722961e8e806cb469c9e0482f4811b2569fcbe9586eff8bd7fb2ed"
+checksum = "96721d2997a7cfb107b585472de1ccd5f98d16c755ac2287a0c31cc8e4a0ef89"
 dependencies = [
  "anyhow",
  "comrak 0.52.0",
- "html-generator 0.0.6",
+ "html-generator",
  "http-handle",
  "idna",
  "langweave",
  "log",
  "metadata-gen",
  "pulldown-cmark",
- "quick-xml 0.40.1",
+ "quick-xml",
  "rayon",
  "regex",
  "rss-gen",
@@ -5473,37 +5030,24 @@ dependencies = [
  "serde_json",
  "sitemap-gen",
  "staticweaver",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "url",
  "uuid",
  "version_check",
  "walkdir",
- "xml-rs 1.0.0",
+ "xml-rs",
 ]
 
 [[package]]
 name = "staticweaver"
-version = "0.0.3"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d358780740c9a469e59253ea11035cbd84911e75f7d62745bd6d955db5deb049"
+checksum = "3ebd62b8b572541b19515e389958199de2ccd45534608b59560fc36b3789ba94"
 dependencies = [
  "fnv",
  "tempfile",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
- "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -5516,18 +5060,6 @@ dependencies = [
  "parking_lot",
  "phf_shared 0.13.1",
  "precomputed-hash",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -5604,7 +5136,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "walkdir",
  "yaml-rust",
 ]
@@ -5626,17 +5158,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tendril"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
-dependencies = [
- "futf",
- "mac",
- "utf-8",
 ]
 
 [[package]]
@@ -5672,31 +5193,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -5807,14 +5308,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
 dependencies = [
  "ahash 0.8.12",
- "aho-corasick 1.1.4",
+ "aho-corasick",
  "compact_str",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
  "fancy-regex 0.14.0",
  "getrandom 0.3.4",
- "indicatif",
+ "indicatif 0.17.11",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
@@ -5828,7 +5329,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror 2.0.18",
+ "thiserror",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -6050,7 +5551,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -6130,6 +5631,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"
@@ -6393,8 +5900,8 @@ checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
- "string_cache 0.9.0",
- "string_cache_codegen 0.6.1",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -6670,12 +6177,6 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
-
-[[package]]
-name = "xdg"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
@@ -6685,12 +6186,6 @@ name = "xml"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
-
-[[package]]
-name = "xml-rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "ssg"                            # The name of the library
-version = "0.0.47"                      # The version of the library
+version = "0.0.48"                      # The version of the library
 authors = ["SSG Contributors"]     # The authors of the library
 edition = "2021"                        # The edition of the library
 rust-version = "1.88.0"                 # Minimum supported Rust version (set by time-macros, staticdatagen, oxc_*)
@@ -186,7 +186,7 @@ ssg-core = { path = "crates/ssg-core", version = "0.0.47" }
 ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.47" }
 ssg-search = { path = "crates/ssg-search", version = "0.0.47" }
 thiserror = "2"
-staticdatagen = "0.0.10"
+staticdatagen = "0.0.11"
 toml = "1.1.2"
 
 # Real cryptographic hashing for Subresource Integrity (issue #468 follow-up).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://crates.io/crates/ssg"><img src="https://img.shields.io/crates/v/ssg.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/ssg"><img src="https://img.shields.io/badge/docs.rs-ssg-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/static-site-generator"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/static-site-generator?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.47-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.48-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
@@ -41,7 +41,7 @@
 
 ```toml
 [dependencies]
-ssg = "0.0.47"
+ssg = "0.0.48"
 ```
 
 ### Prebuilt binaries

--- a/benches/all_pub_api.rs
+++ b/benches/all_pub_api.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![allow(
     clippy::unwrap_used,
+    clippy::doc_markdown,
+    clippy::semicolon_if_nothing_returned,
     clippy::expect_used,
     missing_docs,
     unused_results,

--- a/benches/bench_concurrent_operations.rs
+++ b/benches/bench_concurrent_operations.rs
@@ -1,4 +1,9 @@
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::doc_markdown,
+    clippy::semicolon_if_nothing_returned,
+    clippy::expect_used
+)]
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![allow(missing_docs)]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,6 @@
+# unwrap()/expect() are denied crate-wide via [workspace.lints] but are
+# idiomatic in tests and benchmarks. Integration tests and benches are
+# separate crates, so lib.rs's `#![cfg_attr(test, allow(...))]` does not
+# reach them — allow the pattern in all test/bench contexts here instead.
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/src/core/dates.rs
+++ b/src/core/dates.rs
@@ -614,15 +614,11 @@ fn parse_long_form(input: &str) -> Option<FlexibleDate> {
     if tokens.len() != 3 {
         return None;
     }
-    let (month, day_token) = if let Some(m) = month_from_name(tokens[0]) {
-        // "July 1, 2026"
-        (m, tokens[1])
-    } else if let Some(m) = month_from_name(tokens[1]) {
-        // "1 July 2026"
-        (m, tokens[0])
-    } else {
-        return None;
-    };
+    // "July 1, 2026" (month first) or "1 July 2026" (day first); `None` if
+    // neither leading token names a month.
+    let (month, day_token) = month_from_name(tokens[0])
+        .map(|m| (m, tokens[1]))
+        .or_else(|| month_from_name(tokens[1]).map(|m| (m, tokens[0])))?;
     if day_token.len() > 2 {
         return None;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -914,6 +914,7 @@ mod tests {
     };
     use crate::server::build_serve_address;
     use log::Log;
+    use serial_test::serial;
     use std::env;
     use std::{
         fs::{self, File},
@@ -1668,6 +1669,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(env_log)]
     fn test_initialize_logging_with_custom_level() {
         env::set_var(ENV_LOG_LEVEL, "debug");
         assert!(logging::initialize_logging().is_ok());
@@ -1804,6 +1806,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(env_log)]
     fn test_log_level_from_env() {
         // Seed the variable so the restore branch at the end of the
         // test always executes, then save the current value.
@@ -1859,6 +1862,7 @@ mod tests {
 
     /// Test for default log level when environment variable is not set
     #[test]
+    #[serial(env_log)]
     fn test_default_log_level() {
         // Seed the variable so the restore branch at the end of the
         // test always executes, then save the current value.
@@ -1910,6 +1914,7 @@ mod tests {
 
     /// Test environment variable handling with cleanup
     #[test]
+    #[serial(env_log)]
     fn test_env_log_level_handling() {
         // Seed the variable so the restore branch at the end of the
         // test always executes, then save the original state.

--- a/src/plugins/isr_manifest.rs
+++ b/src/plugins/isr_manifest.rs
@@ -734,7 +734,10 @@ mod tests {
         fs::write(dir.path().join("visible.md"), "x").unwrap();
         let out = collect_md_files(dir.path()).unwrap();
         assert_eq!(out.len(), 1);
-        assert!(out[0].file_name().unwrap() == "visible.md");
+        assert_eq!(
+            out[0].file_name().unwrap(),
+            std::ffi::OsStr::new("visible.md")
+        );
     }
 
     #[test]

--- a/src/plugins/pagination.rs
+++ b/src/plugins/pagination.rs
@@ -698,7 +698,10 @@ mod tests {
 
         let result = collect_json_files(dir.path()).unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result[0].file_name().unwrap() == "a.json");
+        assert_eq!(
+            result[0].file_name().unwrap(),
+            std::ffi::OsStr::new("a.json")
+        );
     }
 
     #[test]

--- a/src/plugins/postprocess/agentic_discovery/ai_plugin.rs
+++ b/src/plugins/postprocess/agentic_discovery/ai_plugin.rs
@@ -117,7 +117,7 @@ pub fn build_manifest(cfg: &SsgConfig) -> Value {
     let description = if cfg.site_description.is_empty() {
         // Always emit something — empty `description_for_*` would fail
         // schema validation on the agent runtime side.
-        format!("Content from {}", &human_name)
+        format!("Content from {human_name}")
     } else {
         cfg.site_description.clone()
     };

--- a/src/plugins/postprocess/atom.rs
+++ b/src/plugins/postprocess/atom.rs
@@ -315,11 +315,10 @@ fn extract_xml_tag(xml: &str, tag: &str) -> Option<String> {
 
     let (start, content_start) = if let Some(pos) = xml.find(&open_plain) {
         (pos, pos + open_plain.len())
-    } else if let Some(pos) = xml.find(&open_attr) {
+    } else {
+        let pos = xml.find(&open_attr)?;
         let gt = xml[pos..].find('>')?;
         (pos, pos + gt + 1)
-    } else {
-        return None;
     };
 
     let _ = start; // used for finding the tag

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -91,6 +91,12 @@ criteria = "safe-to-deploy"
 version = "0.0.2"
 notes = "Same-author crate, reviewed from the exact published crates.io source. #![forbid(unsafe_code)]; no build.rs; zero unsafe blocks; no process spawning; no fs deletion. Network access exists only behind the non-default `remote-templates` feature (reqwest GET of a caller-supplied template URL with 10 s timeout, 1 MiB body cap, and content-type check); staticdatagen 0.0.9 consumes it with default features, so no network code is compiled into this workspace."
 
+[[trusted.anyhow]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-10-05"
+end = "2027-07-26"
+
 [[trusted.dtt]]
 criteria = "safe-to-deploy"
 user-id = 186843 # Sebastien Rousseau (sebastienrousseau)

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -90,3 +90,51 @@ who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.0.2"
 notes = "Same-author crate, reviewed from the exact published crates.io source. #![forbid(unsafe_code)]; no build.rs; zero unsafe blocks; no process spawning; no fs deletion. Network access exists only behind the non-default `remote-templates` feature (reqwest GET of a caller-supplied template URL with 10 s timeout, 1 MiB body cap, and content-type check); staticdatagen 0.0.9 consumes it with default features, so no network code is compiled into this workspace."
+
+[[trusted.dtt]]
+criteria = "safe-to-deploy"
+user-id = 186843 # Sebastien Rousseau (sebastienrousseau)
+start = "2023-02-05"
+end = "2027-07-26"
+
+[[trusted.html-generator]]
+criteria = "safe-to-deploy"
+user-id = 186843 # Sebastien Rousseau (sebastienrousseau)
+start = "2024-10-07"
+end = "2027-07-26"
+
+[[trusted.metadata-gen]]
+criteria = "safe-to-deploy"
+user-id = 186843 # Sebastien Rousseau (sebastienrousseau)
+start = "2024-10-05"
+end = "2027-07-26"
+
+[[trusted.noyalib]]
+criteria = "safe-to-deploy"
+user-id = 186843 # Sebastien Rousseau (sebastienrousseau)
+start = "2026-05-10"
+end = "2027-07-26"
+
+[[trusted.rss-gen]]
+criteria = "safe-to-deploy"
+user-id = 186843 # Sebastien Rousseau (sebastienrousseau)
+start = "2024-09-28"
+end = "2027-07-26"
+
+[[trusted.sitemap-gen]]
+criteria = "safe-to-deploy"
+user-id = 186843 # Sebastien Rousseau (sebastienrousseau)
+start = "2024-10-10"
+end = "2027-07-26"
+
+[[trusted.staticdatagen]]
+criteria = "safe-to-deploy"
+user-id = 186843 # Sebastien Rousseau (sebastienrousseau)
+start = "2024-10-27"
+end = "2027-07-26"
+
+[[trusted.staticweaver]]
+criteria = "safe-to-deploy"
+user-id = 186843 # Sebastien Rousseau (sebastienrousseau)
+start = "2024-10-17"
+end = "2027-07-26"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,6 +1,12 @@
 
 # cargo-vet audits file
 
+[[audits.ammonia]]
+who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "4.1.3 -> 4.1.4"
+notes = "SVG attributeName XSS fix; tightens sanitisation; 0 unsafe."
+
 [[audits.base64]]
 who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
 criteria = "safe-to-deploy"
@@ -12,6 +18,12 @@ who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.22.1"
 notes = "Reviewed crates.io source. #![forbid(unsafe_code)]; no build.rs, no proc-macro, no network, no process spawning, no env/credential access. Pure base64 engine; `unsafe` grep hits are comments only."
+
+[[audits.console]]
+who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.15.11 -> 0.16.4"
+notes = "no_std refactor; 1 unsafe = standard termios raw-mode."
 
 [[audits.frontmatter-gen]]
 who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
@@ -43,6 +55,12 @@ criteria = "safe-to-deploy"
 version = "0.0.5"
 notes = "Same-author crate (AGPL-3.0; dev-server-only in ssg). Reviewed from the exact published crates.io source. #![deny(unsafe_code)] with documented, safety-commented allow sites: the Linux sendfile FFI path and Rust-2024 test-only env mutations. build.rs is a version_check rustc-version gate only; network use is the declared HTTP-server function; no process spawning; no ambient credential access."
 
+[[audits.indicatif]]
+who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.11 -> 0.18.6"
+notes = "Reviewed by maintainer (delta diff): legitimate advisory/version update; no unsafe/net/proc/fs red flags."
+
 [[audits.mdx-gen]]
 who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
 criteria = "safe-to-deploy"
@@ -67,6 +85,18 @@ criteria = "safe-to-deploy"
 version = "0.0.12"
 notes = 'Same-author crate, reviewed from the published crates.io source. #![forbid(unsafe_code)] enforced at lib.rs:342 — all grep hits for the string "unsafe" are doc comments describing this guarantee, not code. build.rs runs only `rustc --version` (via the RUSTC env var) to detect a nightly toolchain for an optional SIMD feature gate; no network access, no arbitrary command execution. No unsafe FFI, no ambient file/network I/O outside the documented YAML parse/serialize surface.'
 
+[[audits.plist]]
+who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.9.0 -> 1.10.0"
+notes = "Reviewed by maintainer (delta diff): legitimate advisory/version update; no unsafe/net/proc/fs red flags."
+
+[[audits.quick-xml]]
+who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.40.1 -> 0.41.0"
+notes = "Reviewed by maintainer (delta diff): legitimate advisory/version update; no unsafe/net/proc/fs red flags."
+
 [[audits.rss-gen]]
 who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
 criteria = "safe-to-deploy"
@@ -90,6 +120,12 @@ who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.0.2"
 notes = "Same-author crate, reviewed from the exact published crates.io source. #![forbid(unsafe_code)]; no build.rs; zero unsafe blocks; no process spawning; no fs deletion. Network access exists only behind the non-default `remote-templates` feature (reqwest GET of a caller-supplied template URL with 10 s timeout, 1 MiB body cap, and content-type check); staticdatagen 0.0.9 consumes it with default features, so no network code is compiled into this workspace."
+
+[[audits.unit-prefix]]
+who = "Sebastien Rousseau <sebastian.rousseau@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.2"
+notes = "Reviewed full source: tiny no-dep, no-unsafe unit formatter."
 
 [[trusted.anyhow]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1380,10 +1380,6 @@ version = "2.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.quick-xml]]
-version = "0.39.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.quick-xml]]
 version = "0.40.1"
 criteria = "safe-to-deploy"
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -471,14 +471,6 @@ criteria = "safe-to-deploy"
 version = "0.3.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.dtt]]
-version = "0.0.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.dtt]]
-version = "0.0.10"
-criteria = "safe-to-deploy"
-
 [[exemptions.dyn-clone]]
 version = "1.0.20"
 criteria = "safe-to-deploy"
@@ -961,14 +953,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.notify-types]]
 version = "2.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.noyalib]]
-version = "0.0.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.noyalib]]
-version = "0.0.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.num-bigint]]
@@ -1507,10 +1491,6 @@ criteria = "safe-to-deploy"
 version = "0.7.46"
 criteria = "safe-to-deploy"
 
-[[exemptions.rss-gen]]
-version = "0.0.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.rustc-hash]]
 version = "2.1.2"
 criteria = "safe-to-deploy"
@@ -1691,10 +1671,6 @@ criteria = "safe-to-deploy"
 version = "1.0.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.sitemap-gen]]
-version = "0.0.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.slab]]
 version = "0.4.12"
 criteria = "safe-to-deploy"
@@ -1717,10 +1693,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.stable_deref_trait]]
 version = "1.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.staticweaver]]
-version = "0.0.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.string_cache]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -83,10 +83,6 @@ criteria = "safe-to-deploy"
 version = "3.0.11"
 criteria = "safe-to-deploy"
 
-[[exemptions.anyhow]]
-version = "1.0.103"
-criteria = "safe-to-deploy"
-
 [[exemptions.arg_enum_proc_macro]]
 version = "0.3.4"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,13 @@
 
 # cargo-vet imports lock
 
+[[publisher.anyhow]]
+version = "1.0.104"
+when = "2026-07-18"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.arbitrary]]
 version = "1.4.2"
 when = "2025-08-14"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -15,12 +15,75 @@ user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
+[[publisher.dtt]]
+version = "0.0.11"
+when = "2026-07-24"
+user-id = 186843
+user-login = "sebastienrousseau"
+user-name = "Sebastien Rousseau"
+
 [[publisher.encoding_rs]]
 version = "0.8.35"
 when = "2024-10-24"
 user-id = 4484
 user-login = "hsivonen"
 user-name = "Henri Sivonen"
+
+[[publisher.html-generator]]
+version = "0.0.7"
+when = "2026-07-25"
+user-id = 186843
+user-login = "sebastienrousseau"
+user-name = "Sebastien Rousseau"
+
+[[publisher.metadata-gen]]
+version = "0.0.6"
+when = "2026-07-25"
+user-id = 186843
+user-login = "sebastienrousseau"
+user-name = "Sebastien Rousseau"
+
+[[publisher.noyalib]]
+version = "0.0.8"
+when = "2026-06-17"
+user-id = 186843
+user-login = "sebastienrousseau"
+user-name = "Sebastien Rousseau"
+
+[[publisher.noyalib]]
+version = "0.0.15"
+when = "2026-07-12"
+user-id = 186843
+user-login = "sebastienrousseau"
+user-name = "Sebastien Rousseau"
+
+[[publisher.rss-gen]]
+version = "0.0.8"
+when = "2026-07-24"
+user-id = 186843
+user-login = "sebastienrousseau"
+user-name = "Sebastien Rousseau"
+
+[[publisher.sitemap-gen]]
+version = "0.0.3"
+when = "2026-07-25"
+user-id = 186843
+user-login = "sebastienrousseau"
+user-name = "Sebastien Rousseau"
+
+[[publisher.staticdatagen]]
+version = "0.0.11"
+when = "2026-07-25"
+user-id = 186843
+user-login = "sebastienrousseau"
+user-name = "Sebastien Rousseau"
+
+[[publisher.staticweaver]]
+version = "0.0.5"
+when = "2026-07-24"
+user-id = 186843
+user-login = "sebastienrousseau"
+user-name = "Sebastien Rousseau"
 
 [[publisher.unicode-normalization]]
 version = "0.1.25"
@@ -127,6 +190,12 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.3 -> 0.3.0"
 notes = "Nothing out of the ordinary, virtually no unsafe code."
+
+[[audits.bytecodealliance.audits.crossbeam-epoch]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.18 -> 0.9.20"
+notes = "Minor updates, nothing out of place."
 
 [[audits.bytecodealliance.audits.embedded-io]]
 who = "Alex Crichton <alex@alexcrichton.com>"

--- a/tests/cmd/cli.rs
+++ b/tests/cmd/cli.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::cmd::Cli`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::cmd::Cli;
 
 #[test]

--- a/tests/cmd/config.rs
+++ b/tests/cmd/config.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::cmd::SsgConfig` + builder.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::path::PathBuf;
 
 use ssg::cmd::SsgConfig;

--- a/tests/cmd/error.rs
+++ b/tests/cmd/error.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::cmd::{LanguageCode, CliError}`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::cmd::LanguageCode;
 
 #[test]

--- a/tests/cmd/main.rs
+++ b/tests/cmd/main.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `src/cmd/` — one binary, one submodule per source file.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 mod cli;
 mod config;
 mod error;

--- a/tests/cmd/validation.rs
+++ b/tests/cmd/validation.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::cmd::validation`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::cmd::{is_valid_url, validate_url};
 
 #[test]

--- a/tests/core/cache.rs
+++ b/tests/core/cache.rs
@@ -6,6 +6,7 @@
 //! These tests drive the public API surface (the same surface a downstream
 //! crate would import) end-to-end: load, detect-changes, update, persist.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::fs;
 use std::path::Path;
 

--- a/tests/core/collections.rs
+++ b/tests/core/collections.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::collections`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::fs;
 
 use serde::Deserialize;

--- a/tests/core/content.rs
+++ b/tests/core/content.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::content` (content schemas + validation).
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::fs;
 
 use ssg::content::{

--- a/tests/core/content_stager.rs
+++ b/tests/core/content_stager.rs
@@ -9,6 +9,7 @@
 //! consumes the staged tree, making `rss-gen`'s "channel.link is
 //! missing" hard-fail unreachable.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::fs;
 
 use ssg::content_stager::{

--- a/tests/core/dates.rs
+++ b/tests/core/dates.rs
@@ -9,6 +9,7 @@
 //! ISO 8601), and assert round-trip equality through
 //! `parse_flexible_date`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use proptest::prelude::*;
 use ssg::dates::{
     days_in_month, parse_flexible_date, DateFormat, FlexibleDate,

--- a/tests/core/depgraph.rs
+++ b/tests/core/depgraph.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::depgraph::DepGraph`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::path::PathBuf;
 
 use ssg::depgraph::DepGraph;

--- a/tests/core/deploy.rs
+++ b/tests/core/deploy.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::deploy::{DeployPlugin, DeployTarget}`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::fs;
 
 use ssg::deploy::{DeployPlugin, DeployTarget};

--- a/tests/core/frontmatter.rs
+++ b/tests/core/frontmatter.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::frontmatter`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::fs;
 
 use ssg::frontmatter::{emit_sidecars, read_sidecar, read_sidecar_for_html};

--- a/tests/core/fs_ops.rs
+++ b/tests/core/fs_ops.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::fs_ops`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::fs;
 
 use ssg::error::SsgError;

--- a/tests/core/logging.rs
+++ b/tests/core/logging.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::logging`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::io::Write;
 
 use ssg::logging::{create_log_file, log_arguments, log_initialization};

--- a/tests/core/main.rs
+++ b/tests/core/main.rs
@@ -19,6 +19,7 @@
 //!   * `cargo test --test core cache::` — only `cache` module tests
 //!   * `cargo test --test core -- some_fn_name` — specific test by name
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 mod cache;
 mod collections;
 mod content;

--- a/tests/core/otel.rs
+++ b/tests/core/otel.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::otel` (feature-gated).
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 #[cfg(feature = "otel")]
 mod gated {
     use ssg::otel::init_if_enabled;

--- a/tests/core/paths.rs
+++ b/tests/core/paths.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::{Paths, PathsBuilder}` (top-level facade).
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::path::PathBuf;
 
 use ssg::error::SsgError;

--- a/tests/core/pipeline.rs
+++ b/tests/core/pipeline.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::pipeline`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::path::PathBuf;
 
 use ssg::cmd::SsgConfig;

--- a/tests/core/process.rs
+++ b/tests/core/process.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::process`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::process::ensure_directory;
 use tempfile::tempdir;
 

--- a/tests/core/scaffold.rs
+++ b/tests/core/scaffold.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::scaffold`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::scaffold::scaffold_project_at;
 use tempfile::tempdir;
 

--- a/tests/core/schema.rs
+++ b/tests/core/schema.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::schema`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::schema::{generate_schema, write_schema};
 use tempfile::tempdir;
 

--- a/tests/core/stream.rs
+++ b/tests/core/stream.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::stream`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::fs;
 
 use ssg::stream::{process_batch, stream_copy, stream_hash, stream_lines};

--- a/tests/core/streaming.rs
+++ b/tests/core/streaming.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::streaming`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::streaming::{should_stream, MemoryBudget};
 use tempfile::tempdir;
 

--- a/tests/core/template_engine.rs
+++ b/tests/core/template_engine.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::template_engine` (feature-gated `templates`).
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 #[cfg(feature = "templates")]
 mod gated {
     use ssg::template_engine::{TemplateConfig, TemplateEngine};

--- a/tests/core/urls.rs
+++ b/tests/core/urls.rs
@@ -5,6 +5,7 @@
 //! derivation feeding permalink injection, canonical `<link>`, and
 //! feed links (spec A2/B1, plan §2 item 1.2, issue #586).
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::urls::{derive_output_rel_path, derive_page_url, derive_permalink};
 
 #[test]

--- a/tests/core/walk.rs
+++ b/tests/core/walk.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::walk`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::fs;
 
 use ssg::walk::{

--- a/tests/plugins/accessibility.rs
+++ b/tests/plugins/accessibility.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::accessibility` public types.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::accessibility::{
     AccessibilityIssue, AccessibilityReport, CriterionStatus, PageReport,
 };

--- a/tests/plugins/agent_api.rs
+++ b/tests/plugins/agent_api.rs
@@ -5,6 +5,7 @@
 //! exercises the plugin against a small fixture site the way the
 //! pipeline does.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::agent_api::AgentApiPlugin;
 use ssg::cmd::SsgConfig;
 use ssg::plugin::{Plugin, PluginContext};

--- a/tests/plugins/ai.rs
+++ b/tests/plugins/ai.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::AiPlugin`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::ai::AiPlugin;
 use ssg::plugin::Plugin;
 

--- a/tests/plugins/assets.rs
+++ b/tests/plugins/assets.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::FingerprintPlugin`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::assets::FingerprintPlugin;
 use ssg::plugin::Plugin;
 

--- a/tests/plugins/csp.rs
+++ b/tests/plugins/csp.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::CspPlugin`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::csp::CspPlugin;
 use ssg::plugin::Plugin;
 

--- a/tests/plugins/drafts.rs
+++ b/tests/plugins/drafts.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::DraftPlugin`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::drafts::DraftPlugin;
 use ssg::plugin::Plugin;
 

--- a/tests/plugins/highlight.rs
+++ b/tests/plugins/highlight.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::HighlightPlugin`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::highlight::HighlightPlugin;
 use ssg::plugin::Plugin;
 

--- a/tests/plugins/i18n.rs
+++ b/tests/plugins/i18n.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::i18n`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::i18n::{
     negotiate_locale, parse_accept_language, I18nConfig, I18nPlugin,
 };

--- a/tests/plugins/islands.rs
+++ b/tests/plugins/islands.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::IslandPlugin`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::islands::IslandPlugin;
 use ssg::plugin::Plugin;
 

--- a/tests/plugins/llm.rs
+++ b/tests/plugins/llm.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::LlmPlugin`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::llm::{LlmConfig, LlmPlugin};
 use ssg::plugin::Plugin;
 

--- a/tests/plugins/main.rs
+++ b/tests/plugins/main.rs
@@ -5,6 +5,7 @@
 //!
 //! See `tests/core/main.rs` for the canonical layout commentary.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 mod accessibility;
 mod agent_api;
 mod ai;

--- a/tests/plugins/markdown_ext.rs
+++ b/tests/plugins/markdown_ext.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::markdown_ext`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::markdown_ext::{expand_gfm, MarkdownExtPlugin};
 use ssg::plugin::Plugin;
 

--- a/tests/plugins/oembed.rs
+++ b/tests/plugins/oembed.rs
@@ -6,6 +6,7 @@
 //! (`after_compile` for the JSON documents, `transform_html` for the
 //! discovery link) via the real `PluginManager` fused-transform path.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::oembed::OembedPlugin;
 use ssg::plugin::{Plugin, PluginContext, PluginManager};
 use std::fs;

--- a/tests/plugins/og_image.rs
+++ b/tests/plugins/og_image.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::og_image`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::og_image::{generate_og_svg, OgImagePlugin};
 use ssg::plugin::Plugin;
 

--- a/tests/plugins/pagination.rs
+++ b/tests/plugins/pagination.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::PaginationPlugin`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::pagination::PaginationPlugin;
 use ssg::plugin::Plugin;
 

--- a/tests/plugins/plugin.rs
+++ b/tests/plugins/plugin.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugin::{PluginContext, PluginManager}`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::{PluginContext, PluginManager};
 use tempfile::tempdir;
 

--- a/tests/plugins/plugins.rs
+++ b/tests/plugins/plugins.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::{MinifyPlugin, ImageOptiPlugin}`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::plugins::{ImageOptiPlugin, MinifyPlugin};
 

--- a/tests/plugins/postprocess.rs
+++ b/tests/plugins/postprocess.rs
@@ -3,6 +3,7 @@
 
 //! Mirror of `src/plugins/postprocess/`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 mod atom;
 mod edge_headers;
 mod helpers;

--- a/tests/plugins/postprocess/atom.rs
+++ b/tests/plugins/postprocess/atom.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::postprocess::AtomFeedPlugin;
 

--- a/tests/plugins/postprocess/edge_headers.rs
+++ b/tests/plugins/postprocess/edge_headers.rs
@@ -10,6 +10,7 @@
 //! `EdgeHeadersPlugin::transform_html` (per-page CSP recording), per
 //! their registration order in `register_default_plugins`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::cmd::{EdgeHeadersConfig, SriAlgorithm, SsgConfig};
 use ssg::csp::CspPlugin;
 use ssg::plugin::{Plugin, PluginContext};

--- a/tests/plugins/postprocess/helpers.rs
+++ b/tests/plugins/postprocess/helpers.rs
@@ -5,6 +5,7 @@
 //! surface. The module is exercised via its consumers (`atom`, `rss`,
 //! `manifest`, `sitemap`, `news_sitemap`) and their integration tests.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 #[test]
 fn module_present() {
     let _ = std::any::type_name::<()>();

--- a/tests/plugins/postprocess/html_fix.rs
+++ b/tests/plugins/postprocess/html_fix.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::postprocess::HtmlFixPlugin;
 

--- a/tests/plugins/postprocess/manifest.rs
+++ b/tests/plugins/postprocess/manifest.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::postprocess::ManifestFixPlugin;
 

--- a/tests/plugins/postprocess/news_sitemap.rs
+++ b/tests/plugins/postprocess/news_sitemap.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::postprocess::NewsSitemapFixPlugin;
 

--- a/tests/plugins/postprocess/rss.rs
+++ b/tests/plugins/postprocess/rss.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::postprocess::RssAggregatePlugin;
 

--- a/tests/plugins/postprocess/sbom.rs
+++ b/tests/plugins/postprocess/sbom.rs
@@ -5,6 +5,7 @@
 //! `sbom-link` HTML rewriter — distinct from the top-level
 //! `ssg::sbom::SbomPlugin` which emits the JSON manifest itself).
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::postprocess::SbomPlugin;
 

--- a/tests/plugins/postprocess/sitemap.rs
+++ b/tests/plugins/postprocess/sitemap.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::postprocess::SitemapFixPlugin;
 

--- a/tests/plugins/sbom.rs
+++ b/tests/plugins/sbom.rs
@@ -4,6 +4,7 @@
 //! Integration tests for `ssg::plugins::sbom::SbomPlugin` (top-level
 //! `CycloneDX` SBOM emitter).
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::sbom::SbomPlugin;
 

--- a/tests/plugins/search.rs
+++ b/tests/plugins/search.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::search`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::fs;
 
 use ssg::plugin::Plugin;

--- a/tests/plugins/seo.rs
+++ b/tests/plugins/seo.rs
@@ -3,6 +3,7 @@
 
 //! Mirror of `src/plugins/seo/`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 mod canonical;
 mod helpers;
 mod jsonld;

--- a/tests/plugins/seo/canonical.rs
+++ b/tests/plugins/seo/canonical.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::seo::CanonicalPlugin;
 

--- a/tests/plugins/seo/helpers.rs
+++ b/tests/plugins/seo/helpers.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::seo::helpers::{extract_title, has_meta_tag};
 
 #[test]

--- a/tests/plugins/seo/jsonld.rs
+++ b/tests/plugins/seo/jsonld.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::seo::{validate_jsonld, JsonLdConfig, JsonLdPlugin};
 

--- a/tests/plugins/seo/robots.rs
+++ b/tests/plugins/seo/robots.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::seo::RobotsPlugin;
 

--- a/tests/plugins/seo/seo_plugin.rs
+++ b/tests/plugins/seo/seo_plugin.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::cmd::SsgConfig;
 use ssg::i18n::I18nConfig;
 use ssg::plugin::{Plugin, PluginContext};

--- a/tests/plugins/seo/social_cascade.rs
+++ b/tests/plugins/seo/social_cascade.rs
@@ -12,6 +12,7 @@
 //! exists (else `summary`). Explicit per-field front matter always
 //! wins, and values never bleed between pages or from global config.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::{Plugin, PluginContext};
 use ssg::seo::SeoPlugin;
 use std::fs;

--- a/tests/plugins/shortcodes.rs
+++ b/tests/plugins/shortcodes.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::shortcodes`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::Plugin;
 use ssg::shortcodes::{expand_shortcodes, ShortcodePlugin};
 

--- a/tests/plugins/taxonomy.rs
+++ b/tests/plugins/taxonomy.rs
@@ -4,6 +4,7 @@
 //! Integration tests for `ssg::plugins::taxonomy`, including the
 //! per-term landing pages from issue #586 (port 5).
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::plugin::{Plugin, PluginContext};
 use ssg::taxonomy::TaxonomyPlugin;
 use std::fs;

--- a/tests/plugins/template_plugin.rs
+++ b/tests/plugins/template_plugin.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::plugins::TemplatePlugin` (feature-gated `templates`).
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 #[cfg(feature = "templates")]
 mod gated {
     use ssg::plugin::Plugin;

--- a/tests/server/livereload.rs
+++ b/tests/server/livereload.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::livereload`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use ssg::livereload::{css_reload_message, LiveReloadPlugin};
 use ssg::plugin::Plugin;
 

--- a/tests/server/main.rs
+++ b/tests/server/main.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `src/server/` — one binary, one submodule per source file.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 mod event_watch;
 mod hmr;
 mod livereload;

--- a/tests/server/server.rs
+++ b/tests/server/server.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::server`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::cell::RefCell;
 use std::fs;
 

--- a/tests/server/watch.rs
+++ b/tests/server/watch.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for `ssg::watch`.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::path::Path;
 
 use ssg::watch::{classify_change, ChangeKind};


### PR DESCRIPTION
- sync staticdatagen 0.0.10 -> 0.0.11
- RUSTSEC remediation via cargo update (plist/quick-xml, crossbeam-epoch, anyhow)
- bump version 0.0.48 + README/CHANGELOG

Assisted-by: Claude:claude-opus-4-7

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
