### PR TITLE
chore(deps): consolidate dependency updates for v0.0.49

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
           fi
       - name: Upload SARIF to GitHub Code Scanning (#562)
         if: always()
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: ssg-audit.sarif
           category: ssg-audit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,12 +39,12 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: rust
           build-mode: none
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:rust"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,7 @@ jobs:
         with:
           platforms: arm64
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -51,6 +51,6 @@ jobs:
           retention-days: 7
 
       - name: Upload SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: scorecard.sarif

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64-simd"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,6 +2583,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9014fb34654ac4f54a4ff52d5207b1e4a764604fced568c3a1d71ee99d1fc300"
 dependencies = [
  "indexmap",
+ "memchr",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "noyalib"
+version = "0.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "179fb3ecf8e64246b67049033e61c739c467c7bb1d79b2c1a65c1ac13f87512a"
+dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "rustc-hash",
@@ -2853,25 +2872,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c54f9bbf7e174b39691080396390a9c6bea6d0dce206660567c1b88951f7b6"
+checksum = "ae912912216c33ad0fb27a544160f3833a5e92a1216d7c4b9aa79a94b39aee98"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
- "oxc_data_structures 0.138.0",
- "rustc-hash",
-]
-
-[[package]]
-name = "oxc_allocator"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ffd0bdf76f7272e208a4f55740d309f303a104f198bf4902a7377ae33e0a34"
-dependencies = [
- "allocator-api2",
- "hashbrown 0.17.1",
- "oxc_data_structures 0.141.0",
+ "oxc_data_structures 0.142.0",
  "rustc-hash",
 ]
 
@@ -2894,38 +2901,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22bf885a47f8e0562ae73e0487ec8f83358bbbca8aad99a8293a9919d6d9e7fe"
+checksum = "6f0d567d1a93714e4b6b14eabe76c45581a25f418f47c297911a43fe4ee99615"
 dependencies = [
  "bitflags 2.13.0",
- "oxc_allocator 0.138.0",
- "oxc_ast_macros 0.138.0",
- "oxc_data_structures 0.138.0",
- "oxc_diagnostics 0.138.0",
- "oxc_estree 0.138.0",
- "oxc_regular_expression 0.138.0",
- "oxc_span 0.138.0",
- "oxc_str 0.138.0",
- "oxc_syntax 0.138.0",
-]
-
-[[package]]
-name = "oxc_ast"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4a9979cd3cebde3db75fafa713d72e6e891827c29e3ed11d005791052456d9"
-dependencies = [
- "bitflags 2.13.0",
- "oxc_allocator 0.141.0",
- "oxc_ast_macros 0.141.0",
- "oxc_data_structures 0.141.0",
- "oxc_diagnostics 0.141.0",
- "oxc_estree 0.141.0",
- "oxc_regular_expression 0.141.0",
- "oxc_span 0.141.0",
- "oxc_str 0.141.0",
- "oxc_syntax 0.141.0",
+ "oxc_allocator 0.142.0",
+ "oxc_ast_macros 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_estree 0.142.0",
+ "oxc_regular_expression 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str",
+ "oxc_syntax 0.142.0",
 ]
 
 [[package]]
@@ -2942,21 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dcc7cd7607a42e3fed0d789535789ac6c16284f941a8aeed251265f29d1e52"
-dependencies = [
- "phf 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "oxc_ast_macros"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0adbaf016626ad630020c2d5f9078809aeb115966a9268b313e920c98e58040"
+checksum = "a3fff81fa6fffffcf13826a6bc352e402a9197ac88ca286e2b09a0c538904708"
 dependencies = [
  "phf 0.14.0",
  "proc-macro2",
@@ -2978,26 +2955,14 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f22557685c3d7e0a7e2fb3038072774a54bb4ac29f934719f628c364d808c15"
+checksum = "d13c8c77043e21d491840a6d52aa00f3ed1432662b096665b6ad702626f3ec5e"
 dependencies = [
- "oxc_allocator 0.138.0",
- "oxc_ast 0.138.0",
- "oxc_span 0.138.0",
- "oxc_syntax 0.138.0",
-]
-
-[[package]]
-name = "oxc_ast_visit"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95874e8d4c97ee55054ae50746347fc6d018d0bed9e4f40fef483eb4cf22825a"
-dependencies = [
- "oxc_allocator 0.141.0",
- "oxc_ast 0.141.0",
- "oxc_span 0.141.0",
- "oxc_syntax 0.141.0",
+ "oxc_allocator 0.142.0",
+ "oxc_ast 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_syntax 0.142.0",
 ]
 
 [[package]]
@@ -3023,23 +2988,22 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9feb869721e14ab8484c697372c468a3df3cb96ca8c02bfe34981fc8d614e9"
+checksum = "d357ba20fd02298c5779c021b52aaaf95a3852c1e64ed791259bdb14e011dbfe"
 dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
- "dragonbox_ecma 0.1.12",
- "itoa",
- "oxc_allocator 0.138.0",
- "oxc_ast 0.138.0",
- "oxc_data_structures 0.138.0",
+ "oxc_allocator 0.142.0",
+ "oxc_ast 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_ecmascript 0.142.0",
  "oxc_index 5.0.0",
- "oxc_semantic 0.138.0",
+ "oxc_semantic 0.142.0",
  "oxc_sourcemap 8.1.0",
- "oxc_span 0.138.0",
- "oxc_str 0.138.0",
- "oxc_syntax 0.138.0",
+ "oxc_span 0.142.0",
+ "oxc_str",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
 ]
 
@@ -3058,13 +3022,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_compat"
-version = "0.141.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba0d6b9b51855cb2255ee1738266163d229696db7225683c0eb809da6adb11b"
+checksum = "99098c71634f822a5906cc3246a1bf8394351f440a7e45df38a9147abc03bb3e"
 dependencies = [
  "cow-utils",
  "oxc-browserslist 3.0.9",
- "oxc_syntax 0.141.0",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
  "serde",
 ]
@@ -3077,15 +3041,9 @@ checksum = "dd090988aa69c1e394f424289abb9bb1281448a072419ca556a07228ad36b854"
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c920b812d5c7cd2c6b914dbeda4a7e6720e1de7869119b6de833ae39bedac9"
-
-[[package]]
-name = "oxc_data_structures"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980c41eb52557e3255ebacd0d0b5406d1c8703a59cb5300938940b91de41a46f"
+checksum = "2d7793b9a760ff426782915100e1f91b4a653873a5b681576214a6eb495d498a"
 
 [[package]]
 name = "oxc_diagnostics"
@@ -3100,20 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2d82feef8bf6118f57dffdc2cd9c22426b438b3f3298bc398bdf596297aeaa"
-dependencies = [
- "cow-utils",
- "oxc-miette 3.0.0",
- "percent-encoding",
-]
-
-[[package]]
-name = "oxc_diagnostics"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d355bdf332e8412c7e7e061bf53ac3bf71956225722e8ce1b9428402d97e9db"
+checksum = "a401193a5bc7f8acc2665763ea5876cad4a64e4e85c55133376620906e34b9e1"
 dependencies = [
  "cow-utils",
  "oxc-miette 3.0.0",
@@ -3137,35 +3084,22 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5382979eb00843975f7dc33b567d9821f818b26f78d3e31ccf94af3cf78a8c"
+checksum = "9f099596aa0f5cb1aac154f7833abc02e0205aac19ce8b2bd21ee1e52973de61"
 dependencies = [
  "cow-utils",
- "num-bigint 0.4.6",
- "num-traits",
- "oxc_allocator 0.138.0",
- "oxc_ast 0.138.0",
- "oxc_regular_expression 0.138.0",
- "oxc_span 0.138.0",
- "oxc_syntax 0.138.0",
-]
-
-[[package]]
-name = "oxc_ecmascript"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3729826d5e8e50b6788c79ae3c5f18b6d4b372fb1d5a926813c0edfa69ee5831"
-dependencies = [
- "cow-utils",
+ "dragonbox_ecma 0.1.12",
+ "itoa",
  "num-bigint 0.5.1",
  "num-traits",
- "oxc_allocator 0.141.0",
- "oxc_ast 0.141.0",
- "oxc_compat 0.141.0",
- "oxc_regular_expression 0.141.0",
- "oxc_span 0.141.0",
- "oxc_syntax 0.141.0",
+ "oxc_allocator 0.142.0",
+ "oxc_ast 0.142.0",
+ "oxc_compat 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_regular_expression 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_syntax 0.142.0",
  "smallvec",
 ]
 
@@ -3177,15 +3111,9 @@ checksum = "af85b24b7e10bf0ccb252f16d38492f51236c1ba146f62013993667cbf7fa649"
 
 [[package]]
 name = "oxc_estree"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9891b86dad0ad62c3ff1585aa0601af7b49bb3d19c7115e3115e2fba3d13d6d2"
-
-[[package]]
-name = "oxc_estree"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aec60e099d4c904848f51e2737f290c665be0ed66fb295def44f2e91891b604"
+checksum = "f2284782be0ac819aa56b815e6448e140e9f4f2c917917ac4ffa8bd7ccc35a3b"
 
 [[package]]
 name = "oxc_index"
@@ -3226,20 +3154,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.141.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9e4f85134b227f4c9d666aec7aa6e47ad8718145c3b6ee76a855197e076ef6"
+checksum = "3bc28a6afde1b1709459b2abf5d4ff359d183c46823988b2b4d19b94652e78c6"
 dependencies = [
  "itertools 0.15.0",
- "oxc_allocator 0.141.0",
- "oxc_ast 0.141.0",
- "oxc_data_structures 0.141.0",
- "oxc_ecmascript 0.141.0",
+ "oxc_allocator 0.142.0",
+ "oxc_ast 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_ecmascript 0.142.0",
  "oxc_index 5.0.0",
- "oxc_semantic 0.141.0",
- "oxc_span 0.141.0",
- "oxc_str 0.141.0",
- "oxc_syntax 0.141.0",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
 ]
 
@@ -3270,27 +3198,27 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.141.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bbf641666aa58ce1a933060fdcbc9fd34bfe676c409fc051f879f9becebee2"
+checksum = "c94f49db01265438fb2889fb189440a323a56771096cb3b7d33a8ad665fccf2f"
 dependencies = [
  "cow-utils",
  "itoa",
- "oxc_allocator 0.141.0",
- "oxc_ast 0.141.0",
- "oxc_ast_visit 0.141.0",
- "oxc_compat 0.141.0",
- "oxc_data_structures 0.141.0",
- "oxc_ecmascript 0.141.0",
+ "oxc_allocator 0.142.0",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_compat 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_ecmascript 0.142.0",
  "oxc_index 5.0.0",
- "oxc_mangler 0.141.0",
- "oxc_parser 0.141.0",
- "oxc_regular_expression 0.141.0",
- "oxc_semantic 0.141.0",
- "oxc_span 0.141.0",
- "oxc_str 0.141.0",
- "oxc_syntax 0.141.0",
- "oxc_traverse 0.141.0",
+ "oxc_mangler 0.142.0",
+ "oxc_parser 0.142.0",
+ "oxc_regular_expression 0.142.0",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str",
+ "oxc_syntax 0.142.0",
+ "oxc_traverse 0.142.0",
  "rustc-hash",
 ]
 
@@ -3319,48 +3247,24 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79d7f27f20413eaeecada4d850aeb0220e70c821d4863d9fb0df115eae62a9"
-dependencies = [
- "bitflags 2.13.0",
- "cow-utils",
- "memchr",
- "num-bigint 0.4.6",
- "num-traits",
- "oxc_allocator 0.138.0",
- "oxc_ast 0.138.0",
- "oxc_data_structures 0.138.0",
- "oxc_diagnostics 0.138.0",
- "oxc_ecmascript 0.138.0",
- "oxc_regular_expression 0.138.0",
- "oxc_span 0.138.0",
- "oxc_str 0.138.0",
- "oxc_syntax 0.138.0",
- "rustc-hash",
- "seq-macro",
-]
-
-[[package]]
-name = "oxc_parser"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8f483bbfae70f4f7c9a90c4a4a3a165685c2d929e0765e35db6db1ac825c32"
+checksum = "ff65aedf1d4364457427d461b827cc43544c5275f2693144a4fdb5fe5c26fbd9"
 dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
  "memchr",
  "num-bigint 0.5.1",
  "num-traits",
- "oxc_allocator 0.141.0",
- "oxc_ast 0.141.0",
- "oxc_data_structures 0.141.0",
- "oxc_diagnostics 0.141.0",
- "oxc_ecmascript 0.141.0",
- "oxc_regular_expression 0.141.0",
- "oxc_span 0.141.0",
- "oxc_str 0.141.0",
- "oxc_syntax 0.141.0",
+ "oxc_allocator 0.142.0",
+ "oxc_ast 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_ecmascript 0.142.0",
+ "oxc_regular_expression 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
  "seq-macro",
 ]
@@ -3383,33 +3287,16 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95bee883f864fb7c75d92ccae3b7db98afc4dce5d0b8b5165e681d93cb010399"
+checksum = "69bc0cfbcd78e42d9aaa72eccb77e62b4b85b671f5d08ff8430aeea9816a8273"
 dependencies = [
  "bitflags 2.13.0",
- "oxc_allocator 0.138.0",
- "oxc_ast_macros 0.138.0",
- "oxc_diagnostics 0.138.0",
- "oxc_span 0.138.0",
- "oxc_str 0.138.0",
- "phf 0.14.0",
- "rustc-hash",
- "unicode-id-start",
-]
-
-[[package]]
-name = "oxc_regular_expression"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a41b057cf6d615e5736e80eddf9f611827fc0927bc1a7f33b4b10e171cfae4d"
-dependencies = [
- "bitflags 2.13.0",
- "oxc_allocator 0.141.0",
- "oxc_ast_macros 0.141.0",
- "oxc_diagnostics 0.141.0",
- "oxc_span 0.141.0",
- "oxc_str 0.141.0",
+ "oxc_allocator 0.142.0",
+ "oxc_ast_macros 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str",
  "phf 0.14.0",
  "rustc-hash",
  "unicode-id-start",
@@ -3438,45 +3325,22 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7074088f38672fbafd4aa79f516835661ff539175858323f287775e2d9c89449"
+checksum = "0293d641451efb4d29bd17ab44e413f8d5daa10e9dc541c7b30ddcf136fd0a4d"
 dependencies = [
  "itertools 0.15.0",
  "memchr",
- "oxc_allocator 0.138.0",
- "oxc_ast 0.138.0",
- "oxc_ast_visit 0.138.0",
- "oxc_data_structures 0.138.0",
- "oxc_diagnostics 0.138.0",
- "oxc_ecmascript 0.138.0",
+ "oxc_allocator 0.142.0",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_ecmascript 0.142.0",
  "oxc_index 5.0.0",
- "oxc_span 0.138.0",
- "oxc_str 0.138.0",
- "oxc_syntax 0.138.0",
- "rustc-hash",
- "self_cell",
- "smallvec",
-]
-
-[[package]]
-name = "oxc_semantic"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfab481b9838e23958cfd03638fcb14672be7ca1a3a23d9a87c1a47a00c7cd8"
-dependencies = [
- "itertools 0.15.0",
- "memchr",
- "oxc_allocator 0.141.0",
- "oxc_ast 0.141.0",
- "oxc_ast_visit 0.141.0",
- "oxc_data_structures 0.141.0",
- "oxc_diagnostics 0.141.0",
- "oxc_ecmascript 0.141.0",
- "oxc_index 5.0.0",
- "oxc_span 0.141.0",
- "oxc_str 0.141.0",
- "oxc_syntax 0.141.0",
+ "oxc_span 0.142.0",
+ "oxc_str",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
  "self_cell",
  "smallvec",
@@ -3523,54 +3387,28 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8faf48e243cdacc96018515701bea560664a4cdef545c1fc50be139c0637db13"
-dependencies = [
- "compact_str 0.9.1",
- "oxc-miette 3.0.0",
- "oxc_allocator 0.138.0",
- "oxc_ast_macros 0.138.0",
- "oxc_estree 0.138.0",
- "oxc_str 0.138.0",
-]
-
-[[package]]
-name = "oxc_span"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adc1cfe13a710b2c948ffd26470351a8f0e44b6d5f72e9f8d62dcd2dbab500a"
+checksum = "890589be8c87e7c0f7a1f0331a9b8d362ebcd3e543125815daa942fd550b0121"
 dependencies = [
  "compact_str 0.10.0",
  "oxc-miette 3.0.0",
- "oxc_allocator 0.141.0",
- "oxc_ast_macros 0.141.0",
- "oxc_estree 0.141.0",
- "oxc_str 0.141.0",
+ "oxc_allocator 0.142.0",
+ "oxc_ast_macros 0.142.0",
+ "oxc_estree 0.142.0",
+ "oxc_str",
 ]
 
 [[package]]
 name = "oxc_str"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7beac249fbb9815b974f1b1c2d22cb59be0c2a4a2ad42f1ee948e2600f4ff04c"
-dependencies = [
- "compact_str 0.9.1",
- "hashbrown 0.17.1",
- "oxc_allocator 0.138.0",
- "oxc_estree 0.138.0",
-]
-
-[[package]]
-name = "oxc_str"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7423b8162376b5dd53e6431d6b25a4917048cbd10429778e9d4ae7701062e239"
+checksum = "91f2b9a92f74a8231f21fccfb4eef937d266a7323d9597ccdcd74c7ad0f951b1"
 dependencies = [
  "compact_str 0.10.0",
  "hashbrown 0.17.1",
- "oxc_allocator 0.141.0",
- "oxc_estree 0.141.0",
+ "oxc_allocator 0.142.0",
+ "oxc_estree 0.142.0",
 ]
 
 [[package]]
@@ -3595,40 +3433,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.138.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbe873bf4a3e494a56ec34f2710cb44309a071fd2c8360b893a12347d584c34"
+checksum = "e54e5c73453878e194df8d77d5cdc9ef525fec8ad25c547cc87162318eda6adb"
 dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
  "dragonbox_ecma 0.1.12",
  "nonmax",
- "oxc_allocator 0.138.0",
- "oxc_ast_macros 0.138.0",
- "oxc_estree 0.138.0",
+ "oxc_allocator 0.142.0",
+ "oxc_ast_macros 0.142.0",
+ "oxc_estree 0.142.0",
  "oxc_index 5.0.0",
- "oxc_span 0.138.0",
- "oxc_str 0.138.0",
- "phf 0.14.0",
- "unicode-id-start",
-]
-
-[[package]]
-name = "oxc_syntax"
-version = "0.141.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6a9cea50ff9fa2c17bdb1dec8ab69d0e934015b2ba1414040da7f8db822154"
-dependencies = [
- "bitflags 2.13.0",
- "cow-utils",
- "dragonbox_ecma 0.1.12",
- "nonmax",
- "oxc_allocator 0.141.0",
- "oxc_ast_macros 0.141.0",
- "oxc_estree 0.141.0",
- "oxc_index 5.0.0",
- "oxc_span 0.141.0",
- "oxc_str 0.141.0",
+ "oxc_span 0.142.0",
+ "oxc_str",
  "phf 0.14.0",
  "unicode-id-start",
 ]
@@ -3653,20 +3471,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.141.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31912d26fa60335e443119368a25b737a3fdc60985fb46fa013e511b825c40f2"
+checksum = "9818ac3bf30b98c62780109fada61f6f2d2ce637ae53f94b18dcfad8f9a93600"
 dependencies = [
  "itoa",
- "oxc_allocator 0.141.0",
- "oxc_ast 0.141.0",
- "oxc_ast_visit 0.141.0",
- "oxc_data_structures 0.141.0",
- "oxc_ecmascript 0.141.0",
- "oxc_semantic 0.141.0",
- "oxc_span 0.141.0",
- "oxc_str 0.141.0",
- "oxc_syntax 0.141.0",
+ "oxc_allocator 0.142.0",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_ecmascript 0.142.0",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
 ]
 
@@ -4826,9 +4644,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -4840,13 +4658,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5029,10 +4847,10 @@ dependencies = [
 
 [[package]]
 name = "ssg"
-version = "0.0.48"
+version = "0.0.49"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64 0.23.1",
  "clap",
  "criterion",
  "fail",
@@ -5045,12 +4863,12 @@ dependencies = [
  "minify-html",
  "minijinja",
  "notify",
- "noyalib 0.0.15",
- "oxc_allocator 0.141.0",
- "oxc_codegen 0.138.0",
- "oxc_minifier 0.141.0",
- "oxc_parser 0.138.0",
- "oxc_span 0.138.0",
+ "noyalib 0.0.17",
+ "oxc_allocator 0.142.0",
+ "oxc_codegen 0.142.0",
+ "oxc_minifier 0.142.0",
+ "oxc_parser 0.142.0",
+ "oxc_span 0.142.0",
  "proptest",
  "pulldown-cmark",
  "ravif",
@@ -5093,7 +4911,7 @@ name = "ssg-core"
 version = "0.0.47"
 dependencies = [
  "log",
- "noyalib 0.0.15",
+ "noyalib 0.0.17",
  "pulldown-cmark",
  "serde",
  "serde_json",
@@ -5121,7 +4939,7 @@ version = "0.0.47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "ssg"                            # The name of the library
-version = "0.0.48"                      # The version of the library
+version = "0.0.49"                      # The version of the library
 authors = ["SSG Contributors"]     # The authors of the library
 edition = "2021"                        # The edition of the library
 rust-version = "1.88.0"                 # Minimum supported Rust version (set by time-macros, staticdatagen, oxc_*)
@@ -147,7 +147,7 @@ version_check = "0.9.5"                   # Ensures that a compatible Rust versi
 [dev-dependencies]
 # Dependencies required for testing and development.
 criterion = "0.8.2"                       # Benchmarking library to test performance
-serial_test = "3.2"                        # Serialise fail-rs failpoint tests so they don't race
+serial_test = "4.0"                        # Serialise fail-rs failpoint tests so they don't race
 uuid = { version = "1.23.1", features = ["v4"] }
 fail = { version = "0.5", features = ["failpoints"] }  # Fault injection for tests/fault_injection.rs
 tempfile = "3.27.0"
@@ -194,7 +194,7 @@ toml = "1.1.2"
 # integrity attributes. `sha2` is the de-facto standard SHA-2 implementation;
 # `base64` emits the canonical base64 encoding that browsers expect.
 sha2 = "0.11"
-base64 = "0.22"
+base64 = "0.23"
 
 # adr: ADR-0005 — `ureq` is the LLM transport. See docs/adrs/0005-ureq-for-llm.md.
 # Synchronous, blocking, pure-Rust HTTP client for the local-LLM content
@@ -250,11 +250,11 @@ rgb = { version = "0.8", optional = true }
 # Versions pinned to those already resolved transitively via
 # staticdatagen to keep the dependency graph tight.
 minify-html = { version = "0.18.1", optional = true }
-oxc_minifier = { version = "0.141.0", optional = true }
-oxc_parser = { version = "0.138.0", optional = true }
-oxc_codegen = { version = "0.138.0", optional = true }
-oxc_allocator = { version = "0.141.0", optional = true }
-oxc_span = { version = "0.138.0", optional = true }
+oxc_minifier = { version = "0.142.0", optional = true }
+oxc_parser = { version = "0.142.0", optional = true }
+oxc_codegen = { version = "0.142.0", optional = true }
+oxc_allocator = { version = "0.142.0", optional = true }
+oxc_span = { version = "0.142.0", optional = true }
 lightningcss = { version = "1.0.0-alpha.71", optional = true }
 walkdir = { version = "2.5", optional = true }
 
@@ -269,7 +269,7 @@ frontmatter-gen = "0.0.6"
 # `ssg-core`'s frontmatter parser) — zero unsafe, no C deps, and
 # deliberately carries no dependency on the unmaintained `serde_yaml`
 # lineage `serde_yaml_ng` forked from.
-noyalib = "0.0.15"
+noyalib = "0.0.17"
 
 # Optional observability stack (issue #422). Both crates are
 # `optional = true` — they enter the build only when the `otel`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://crates.io/crates/ssg"><img src="https://img.shields.io/crates/v/ssg.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/ssg"><img src="https://img.shields.io/badge/docs.rs-ssg-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/static-site-generator"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/static-site-generator?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.48-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.49-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
@@ -41,7 +41,7 @@
 
 ```toml
 [dependencies]
-ssg = "0.0.48"
+ssg = "0.0.49"
 ```
 
 ### Prebuilt binaries

--- a/crates/ssg-core/Cargo.toml
+++ b/crates/ssg-core/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1"
 # `serde_yaml` fork) — zero unsafe, no C deps, deliberately no
 # dependency on the unmaintained `serde_yaml` lineage, clean on
 # `wasm32-unknown-unknown`.
-noyalib = "0.0.15"
+noyalib = "0.0.17"
 sha2 = { version = "0.11", default-features = false }
 toml = "1"
 

--- a/crates/ssg-rpc-macro/Cargo.toml
+++ b/crates/ssg-rpc-macro/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2", features = ["full"] }
+syn = { version = "3", features = ["full"] }
 
 [lints]
 workspace = true

--- a/crates/ssg-rpc/benches/dispatch.rs
+++ b/crates/ssg-rpc/benches/dispatch.rs
@@ -9,9 +9,10 @@
 //! native bench target at **≤ 500 µs p99** which gives a comfortable
 //! 10× headroom.
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::hint::black_box;
 
 use ssg_rpc::{
     dispatch, schema_for, schema_for_result, RpcDescriptor, RpcDescriptorRef,

--- a/crates/ssg-search/benches/search_latency.rs
+++ b/crates/ssg-search/benches/search_latency.rs
@@ -74,13 +74,13 @@ fn main() {
     ];
 
     // Warm-up.
-    for q in queries.iter() {
+    for q in &queries {
         let _ = engine.search(q, 10);
     }
 
     let mut samples = Vec::with_capacity(1000);
     for _ in 0..100 {
-        for q in queries.iter() {
+        for q in &queries {
             let t0 = Instant::now();
             let r = engine.search(q, 10);
             let elapsed_us = t0.elapsed().as_secs_f64() * 1e6;

--- a/crates/ssg-search/src/artifacts.rs
+++ b/crates/ssg-search/src/artifacts.rs
@@ -606,7 +606,7 @@ mod tests {
                     arts.embeddings[offset + 2],
                     arts.embeddings[offset + 3],
                 ]);
-                sumsq += f * f;
+                sumsq = f.mul_add(f, sumsq);
             }
             let norm = sumsq.sqrt();
             // AC5: norm within [0.999, 1.001]

--- a/deny.toml
+++ b/deny.toml
@@ -69,4 +69,12 @@ ignore = [
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
     "RUSTSEC-2026-0173", # proc-macro-error2 (unmaintained) — via defmt-macros/defmt, an optional jiff feature
+    # rkyv 0.7.46: shared-pointer validation in the checked `access` API can
+    # read out of bounds on an archive containing Rc/Arc. Fixed in 0.8.17,
+    # which is not reachable: the only path is lightningcss 1.0.0-alpha.72 →
+    # parcel_sourcemap 2.1.1 → rkyv 0.7, and lightningcss has not moved to
+    # rkyv 0.8. lightningcss uses rkyv for its own build-time sourcemap
+    # data; ssg never deserialises an rkyv archive from user input, so the
+    # unsound path is unreachable here. Revisit when lightningcss updates.
+    "RUSTSEC-2026-0235",
 ]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -40,10 +40,6 @@ version = "0.8.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.aho-corasick]]
-version = "0.7.20"
-criteria = "safe-to-deploy"
-
-[[exemptions.aho-corasick]]
 version = "1.1.4"
 criteria = "safe-to-deploy"
 
@@ -111,6 +107,10 @@ criteria = "safe-to-deploy"
 version = "0.8.9"
 criteria = "safe-to-deploy"
 
+[[exemptions.base64]]
+version = "0.23.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.base64-simd]]
 version = "0.7.0"
 criteria = "safe-to-deploy"
@@ -123,10 +123,6 @@ criteria = "safe-to-deploy"
 version = "1.3.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.bit-matrix]]
-version = "0.8.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.bitflags]]
 version = "2.13.0"
 criteria = "safe-to-deploy"
@@ -137,10 +133,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.bitvec]]
 version = "1.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.block-buffer]]
-version = "0.10.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.block-buffer]]
@@ -191,56 +183,28 @@ criteria = "safe-to-deploy"
 version = "1.2.65"
 criteria = "safe-to-deploy"
 
-[[exemptions.cfg]]
-version = "0.9.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.cfg-classify]]
-version = "0.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.cfg-earley]]
-version = "0.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.cfg-generate]]
-version = "0.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.cfg-grammar]]
-version = "0.0.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.cfg-if]]
 version = "1.0.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.cfg-predict]]
-version = "0.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.cfg-sequence]]
-version = "0.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.cfg-symbol]]
-version = "0.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cfg_aliases]]
 version = "0.2.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.chacha20]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.clap]]
-version = "4.6.1"
+version = "4.6.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_builder]]
-version = "4.6.0"
+version = "4.6.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_derive]]
-version = "4.6.1"
+version = "4.6.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_lex]]
@@ -259,12 +223,8 @@ criteria = "safe-to-deploy"
 version = "0.9.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.comrak]]
-version = "0.28.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.comrak]]
-version = "0.32.0"
+[[exemptions.compact_str]]
+version = "0.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.comrak]]
@@ -284,11 +244,7 @@ version = "0.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.const-str]]
-version = "0.3.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.const-str-proc-macro]]
-version = "0.3.2"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.convert_case]]
@@ -297,10 +253,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.cow-utils]]
 version = "0.1.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.cpufeatures]]
-version = "0.2.17"
 criteria = "safe-to-deploy"
 
 [[exemptions.cpufeatures]]
@@ -340,11 +292,11 @@ version = "0.2.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.crypto-common]]
-version = "0.1.7"
+version = "0.2.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.crypto-common]]
-version = "0.2.2"
+[[exemptions.cssparser-color]]
+version = "0.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ctrlc]]
@@ -420,23 +372,11 @@ version = "0.20.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.derive_more]]
-version = "0.99.20"
-criteria = "safe-to-deploy"
-
-[[exemptions.derive_more]]
 version = "2.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.derive_more-impl]]
 version = "2.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.deunicode]]
-version = "1.6.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.digest]]
-version = "0.10.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.digest]]
@@ -469,10 +409,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.dyn-clone]]
 version = "1.0.20"
-criteria = "safe-to-deploy"
-
-[[exemptions.ego-tree]]
-version = "0.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ego-tree]]
@@ -563,10 +499,6 @@ criteria = "safe-to-deploy"
 version = "2.0.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.futf]]
-version = "0.1.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.futures-core]]
 version = "0.3.32"
 criteria = "safe-to-deploy"
@@ -581,10 +513,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.futures-util]]
 version = "0.3.32"
-criteria = "safe-to-deploy"
-
-[[exemptions.generic-array]]
-version = "0.14.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.getopts]]
@@ -621,10 +549,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.html-escape]]
 version = "0.2.13"
-criteria = "safe-to-deploy"
-
-[[exemptions.html5ever]]
-version = "0.29.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.html5ever]]
@@ -788,7 +712,7 @@ version = "0.2.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.lightningcss]]
-version = "1.0.0-alpha.71"
+version = "1.0.0-alpha.72"
 criteria = "safe-to-deploy"
 
 [[exemptions.lightningcss-derive]]
@@ -819,24 +743,12 @@ criteria = "safe-to-deploy"
 version = "0.1.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.mac]]
-version = "0.1.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.maplit]]
 version = "1.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.markup5ever]]
-version = "0.14.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.markup5ever]]
 version = "0.39.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.match_token]]
-version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.matrixmultiply]]
@@ -864,23 +776,11 @@ version = "0.3.8"
 criteria = "safe-to-run"
 
 [[exemptions.minify-html]]
-version = "0.15.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.minify-html]]
 version = "0.18.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minify-html-common]]
-version = "0.0.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.minify-html-common]]
 version = "0.0.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.minify-js]]
-version = "0.5.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.minijinja]]
@@ -953,6 +853,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.num-bigint]]
 version = "0.4.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-bigint]]
+version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.num-complex]]
@@ -1032,7 +936,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_allocator]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ast]]
@@ -1040,7 +944,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ast]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ast_macros]]
@@ -1048,7 +952,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ast_macros]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ast_visit]]
@@ -1056,7 +960,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ast_visit]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_codegen]]
@@ -1064,7 +968,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_codegen]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_compat]]
@@ -1072,7 +976,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_compat]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_data_structures]]
@@ -1080,7 +984,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_data_structures]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_diagnostics]]
@@ -1088,7 +992,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_diagnostics]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ecmascript]]
@@ -1096,7 +1000,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ecmascript]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_estree]]
@@ -1104,7 +1008,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_estree]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_index]]
@@ -1120,7 +1024,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_mangler]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_minifier]]
@@ -1128,7 +1032,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_minifier]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_parser]]
@@ -1136,7 +1040,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_parser]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_regular_expression]]
@@ -1144,7 +1048,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_regular_expression]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_semantic]]
@@ -1152,7 +1056,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_semantic]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_sourcemap]]
@@ -1168,11 +1072,11 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_span]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_str]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_syntax]]
@@ -1180,7 +1084,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_syntax]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_traverse]]
@@ -1188,7 +1092,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_traverse]]
-version = "0.138.0"
+version = "0.142.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.page_size]]
@@ -1196,7 +1100,7 @@ version = "0.6.0"
 criteria = "safe-to-run"
 
 [[exemptions.parcel_selectors]]
-version = "0.28.2"
+version = "0.28.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.parcel_sourcemap]]
@@ -1209,10 +1113,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.parking_lot_core]]
 version = "0.9.12"
-criteria = "safe-to-deploy"
-
-[[exemptions.parse-js]]
-version = "0.17.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.paste]]
@@ -1261,10 +1161,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.phf_generator]]
 version = "0.14.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.phf_macros]]
-version = "0.11.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.phf_macros]]
@@ -1336,7 +1232,7 @@ version = "0.2.37"
 criteria = "safe-to-deploy"
 
 [[exemptions.proc-macro2]]
-version = "1.0.106"
+version = "1.0.107"
 criteria = "safe-to-deploy"
 
 [[exemptions.profiling]]
@@ -1384,7 +1280,7 @@ version = "0.40.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.quote]]
-version = "1.0.46"
+version = "1.0.47"
 criteria = "safe-to-deploy"
 
 [[exemptions.r-efi]]
@@ -1403,12 +1299,20 @@ criteria = "safe-to-deploy"
 version = "0.9.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.rand]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.rand_chacha]]
 version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rand_core]]
 version = "0.9.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_core]]
+version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rand_xorshift]]
@@ -1540,14 +1444,6 @@ version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.scraper]]
-version = "0.22.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.scraper]]
-version = "0.23.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.scraper]]
 version = "0.27.0"
 criteria = "safe-to-deploy"
 
@@ -1572,7 +1468,7 @@ version = "0.3.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde]]
-version = "1.0.228"
+version = "1.0.229"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde-content]]
@@ -1584,11 +1480,11 @@ version = "0.6.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_core]]
-version = "1.0.228"
+version = "1.0.229"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_derive]]
-version = "1.0.228"
+version = "1.0.229"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_derive_internals]]
@@ -1600,7 +1496,7 @@ version = "0.1.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_json]]
-version = "1.0.150"
+version = "1.0.151"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_spanned]]
@@ -1612,15 +1508,19 @@ version = "1.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serial_test]]
-version = "3.5.0"
+version = "4.0.1"
 criteria = "safe-to-run"
 
 [[exemptions.serial_test_derive]]
-version = "3.5.0"
+version = "4.0.1"
 criteria = "safe-to-run"
 
 [[exemptions.servo_arc]]
 version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.sha1]]
+version = "0.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.sha2]]
@@ -1667,10 +1567,6 @@ criteria = "safe-to-deploy"
 version = "0.4.12"
 criteria = "safe-to-deploy"
 
-[[exemptions.slug]]
-version = "0.1.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.smawk]]
 version = "0.3.3"
 criteria = "safe-to-deploy"
@@ -1688,15 +1584,7 @@ version = "1.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.string_cache]]
-version = "0.8.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.string_cache]]
 version = "0.9.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.string_cache_codegen]]
-version = "0.5.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.string_cache_codegen]]
@@ -1713,6 +1601,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.syn]]
 version = "2.0.118"
+criteria = "safe-to-deploy"
+
+[[exemptions.syn]]
+version = "3.0.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.synstructure]]
@@ -1732,10 +1624,6 @@ version = "3.27.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tendril]]
-version = "0.4.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.tendril]]
 version = "0.5.0"
 criteria = "safe-to-deploy"
 
@@ -1748,19 +1636,11 @@ version = "0.16.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
-version = "1.0.69"
-criteria = "safe-to-deploy"
-
-[[exemptions.thiserror]]
-version = "2.0.18"
+version = "2.0.19"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
-version = "1.0.69"
-criteria = "safe-to-deploy"
-
-[[exemptions.thiserror-impl]]
-version = "2.0.18"
+version = "2.0.19"
 criteria = "safe-to-deploy"
 
 [[exemptions.thread_local]]
@@ -1808,7 +1688,7 @@ version = "0.8.23"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml]]
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_datetime]]
@@ -1832,7 +1712,7 @@ version = "0.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_writer]]
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tracing]]
@@ -1864,7 +1744,7 @@ version = "0.2.6"
 criteria = "safe-to-run"
 
 [[exemptions.tungstenite]]
-version = "0.29.0"
+version = "0.30.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.typed-arena]]
@@ -1916,7 +1796,7 @@ version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
-version = "1.23.4"
+version = "1.24.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.v_frame]]
@@ -2132,19 +2012,11 @@ version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.xdg]]
-version = "2.5.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.xdg]]
 version = "3.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.xml]]
 version = "1.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.xml-rs]]
-version = "0.8.28"
 criteria = "safe-to-deploy"
 
 [[exemptions.xml-rs]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -64,6 +64,13 @@ user-id = 186843
 user-login = "sebastienrousseau"
 user-name = "Sebastien Rousseau"
 
+[[publisher.noyalib]]
+version = "0.0.17"
+when = "2026-07-25"
+user-id = 186843
+user-login = "sebastienrousseau"
+user-name = "Sebastien Rousseau"
+
 [[publisher.rss-gen]]
 version = "0.0.8"
 when = "2026-07-24"
@@ -228,18 +235,6 @@ initialization which looks correct to me.
 [[audits.bytecodealliance.audits.hashbrown]]
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
-delta = "0.12.3 -> 0.13.1"
-notes = "The diff looks plausible. Much of it is low-level memory-layout code and I can't be 100% certain without a deeper dive into the implementation logic, but nothing looks actively malicious."
-
-[[audits.bytecodealliance.audits.hashbrown]]
-who = "Trevor Elliott <telliott@fastly.com>"
-criteria = "safe-to-deploy"
-delta = "0.13.1 -> 0.13.2"
-notes = "I read through the diff between v0.13.1 and v0.13.2, and verified that the changes made matched up with the changelog entries. There were very few changes between these two releases, and it was easy to verify what they did."
-
-[[audits.bytecodealliance.audits.hashbrown]]
-who = "Chris Fallin <chris@cfallin.org>"
-criteria = "safe-to-deploy"
 delta = "0.14.5 -> 0.15.2"
 
 [[audits.bytecodealliance.audits.heck]]
@@ -362,12 +357,6 @@ criteria = "safe-to-deploy"
 delta = "1.0.8 -> 1.1.3"
 notes = "Substantial updates, but nothing out of the ordinary one would expect from a serialization crate. Minor `unsafe` updates, but nothing major from what was already there."
 
-[[audits.bytecodealliance.audits.sha1]]
-who = "Andrew Brown <andrew.brown@intel.com>"
-criteria = "safe-to-deploy"
-delta = "0.10.5 -> 0.10.6"
-notes = "Only new code is some loongarch64 additions which include assembly code for that platform."
-
 [[audits.bytecodealliance.audits.sharded-slab]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -440,13 +429,6 @@ think this justifies marking this crate as `ub-risk-1`.
 
 Additional review comments can be found at https://crrev.com/c/4723145/31
 """
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.byteorder]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-deploy"
-version = "1.5.0"
-notes = "Unsafe review in https://crrev.com/c/5838022"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.cast]]
@@ -661,13 +643,6 @@ notes = """
 For more detailed unsafe review notes please see https://crrev.com/c/6362797
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.sha1]]
-who = "David Koloski <dkoloski@google.com>"
-criteria = "safe-to-deploy"
-version = "0.10.5"
-notes = "Reviewed on https://fxrev.dev/712371."
-aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.smallvec]]
 who = "Manish Goregaokar <manishearth@google.com>"
@@ -887,12 +862,6 @@ criteria = "safe-to-deploy"
 delta = "0.36.0 -> 0.37.0"
 notes = "First-party code"
 
-[[audits.mozilla.audits.cssparser-color]]
-who = "Emilio Cobos Álvarez <emilio@crisal.io>"
-criteria = "safe-to-deploy"
-version = "0.1.0"
-notes = "This code used to live in cssparser's color module. Only moved out. Mozilla-authored."
-
 [[audits.mozilla.audits.cssparser-macros]]
 who = "Emilio Cobos Álvarez <emilio@crisal.io>"
 criteria = "safe-to-deploy"
@@ -943,12 +912,6 @@ delta = "1.2.0 -> 1.2.1"
 who = "edgul <ed.guloien@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "1.2.1 -> 1.2.2"
-
-[[audits.mozilla.audits.fxhash]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-version = "0.2.1"
-notes = "Straightforward crate with no unsafe code, does what it says on the tin."
 
 [[audits.mozilla.audits.hashbrown]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
@@ -1087,12 +1050,6 @@ Fixes RUSTSEC-2026-0097 by removing `log` dependency. Removes `simd_support`
 feature. No new dependencies or unsafe code.
 """
 
-[[audits.mozilla.audits.rustc-hash]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-version = "1.1.0"
-notes = "Straightforward crate with no unsafe code, does what it says on the tin."
-
 [[audits.mozilla.audits.seahash]]
 who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -1103,27 +1060,6 @@ grabbing u64s out of the buffer for XORs. Logic looks sound,
 careful not to read over the end of the buffer, and the unsafety
 is well contained.
 """
-
-[[audits.mozilla.audits.selectors]]
-who = "Emilio Cobos Álvarez <emilio@crisal.io>"
-criteria = "safe-to-deploy"
-version = "0.22.0"
-notes = """
-This crate is basically developed in-tree. Mozilla employees have either
-reviewed or written virtually all of the code.
-"""
-
-[[audits.mozilla.audits.selectors]]
-who = "Emilio Cobos Álvarez <emilio@crisal.io>"
-criteria = "safe-to-deploy"
-delta = "0.22.0 -> 0.25.0"
-notes = "First party Mozilla code."
-
-[[audits.mozilla.audits.selectors]]
-who = "Emilio Cobos Álvarez <emilio@crisal.io>"
-criteria = "safe-to-deploy"
-delta = "0.25.0 -> 0.26.0"
-notes = "First-party code."
 
 [[audits.mozilla.audits.sharded-slab]]
 who = "Mark Hammond <mhammond@skippinet.com.au>"

--- a/tests/a11y/package-lock.json
+++ b/tests/a11y/package-lock.json
@@ -748,9 +748,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Consolidates the open Dependabot PRs into a single release branch and bumps the version to `0.0.49`.

### Superseded updates

| PR | Update |
|----|--------|
| #652 | chore(deps-dev): bump ip-address from 10.2.0 to 10.4.0 in /tests/a11y |
| #651 | chore(deps): bump github/codeql-action/init from 4.37.3 to 4.37.4 |
| #650 | chore(deps): bump noyalib from 0.0.15 to 0.0.17 |
| #649 | chore(deps): bump oxc_minifier from 0.141.0 to 0.142.0 |
| #648 | chore(deps): bump syn from 2.0.118 to 3.0.3 |
| #647 | chore(deps): bump oxc_span from 0.138.0 to 0.141.0 |
| #646 | chore(deps): bump oxc_allocator from 0.141.0 to 0.142.0 |
| #645 | chore(deps): bump docker/login-action from 4.5.1 to 4.6.0 |
| #644 | chore(deps): bump oxc_codegen from 0.138.0 to 0.142.0 |
| #643 | chore(deps): bump serial_test from 3.5.0 to 4.0.1 |
| #642 | chore(deps): bump oxc_parser from 0.138.0 to 0.141.0 |
| #641 | chore(deps): bump base64 from 0.22.1 to 0.23.0 |
| #640 | chore(deps): bump the minor-and-patch group with 3 updates |
| #639 | chore(deps): bump github/codeql-action/upload-sarif from 4.37.3 to 4.37.4 |
| #638 | chore(deps): bump github/codeql-action/analyze from 4.37.3 to 4.37.4 |

### Verification

- `cargo fmt --all --check` clean ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean ✅ (**was failing on `main`**)
- `cargo test --lib --features test-fault-injection` (the flags CI uses) — **3573 passed, 0 failed** ✅

### The oxc family is bumped in lockstep, not piecemeal

Dependabot opened five separate oxc PRs proposing *different* targets — parser/span → 0.141, codegen/allocator/minifier → 0.142. Applied individually those would have left the family straddling two releases, on top of `main` already being split (minifier/allocator 0.141, parser/codegen/span 0.138). All five now sit on **0.142.0** together.

Note this makes #632 (`feat/v0.0.49`, "oxc 0.138→0.141 lockstep bump") largely redundant for the oxc part — it targets the older 0.141 and is currently conflicting. Left open for you to decide.

### Pre-existing clippy failures fixed

`main` did not pass `clippy -D warnings`. Three fixes, none related to the dependency bumps:
- `ssg-search/src/artifacts.rs` — `suboptimal_flops`; now uses `f.mul_add(f, sumsq)`.
- `ssg-search/benches/search_latency.rs` — `explicit_iter_loop` ×2.
- `ssg-rpc/benches/dispatch.rs` — `criterion::black_box` is deprecated; switched to `std::hint::black_box`.
